### PR TITLE
Encode base64 for the posting message payload [21728]

### DIFF
--- a/Credify.xcodeproj/project.pbxproj
+++ b/Credify.xcodeproj/project.pbxproj
@@ -46,6 +46,8 @@
 		2517EC9127E5AFC80025E396 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 2517EC9027E5AFC80025E396 /* README.md */; };
 		DB85CE1B990000350661FBD5 /* Pods_Credify_CredifyTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D89DA42E91785C838AB2CC6F /* Pods_Credify_CredifyTests.framework */; };
 		E0C17D0D9B8627E0F7DBC0A5 /* Pods_Credify.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C7A244039A269E07690C793C /* Pods_Credify.framework */; };
+		F83B400427E89DF200A01A2E /* PostMessageUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = F83B400327E89DF200A01A2E /* PostMessageUtils.swift */; };
+		F83B400627E89E7300A01A2E /* PostMessageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F83B400527E89E7300A01A2E /* PostMessageModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -104,6 +106,8 @@
 		C7A244039A269E07690C793C /* Pods_Credify.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Credify.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D89DA42E91785C838AB2CC6F /* Pods_Credify_CredifyTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Credify_CredifyTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EAE2E90792E6563322DB1C3E /* Pods-Credify-CredifyTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Credify-CredifyTests.debug.xcconfig"; path = "Target Support Files/Pods-Credify-CredifyTests/Pods-Credify-CredifyTests.debug.xcconfig"; sourceTree = "<group>"; };
+		F83B400327E89DF200A01A2E /* PostMessageUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostMessageUtils.swift; sourceTree = "<group>"; };
+		F83B400527E89E7300A01A2E /* PostMessageModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostMessageModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -152,6 +156,7 @@
 		2517EBFD27E57CED0025E396 /* Credify */ = {
 			isa = PBXGroup;
 			children = (
+				F83B400227E89DF200A01A2E /* Utils */,
 				2517EC6E27E5A4730025E396 /* Assets.xcassets */,
 				2517EC4627E5A4520025E396 /* Fonts */,
 				2517EC5427E5A4520025E396 /* Network */,
@@ -195,6 +200,7 @@
 		2517EC3C27E5A4510025E396 /* Objects */ = {
 			isa = PBXGroup;
 			children = (
+				F83B400527E89E7300A01A2E /* PostMessageModel.swift */,
 				2517EC3D27E5A4510025E396 /* AppState.swift */,
 				2517EC3E27E5A4510025E396 /* CredifyEnvs.swift */,
 				2517EC3F27E5A4510025E396 /* Entities.swift */,
@@ -295,6 +301,15 @@
 				D89DA42E91785C838AB2CC6F /* Pods_Credify_CredifyTests.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		F83B400227E89DF200A01A2E /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				F83B400327E89DF200A01A2E /* PostMessageUtils.swift */,
+			);
+			name = Utils;
+			path = Credify/Utils;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -490,11 +505,13 @@
 				2517EC5927E5A4520025E396 /* AppState.swift in Sources */,
 				2517EC6927E5A4520025E396 /* ThemeColor.swift in Sources */,
 				2517EC5B27E5A4520025E396 /* Entities.swift in Sources */,
+				F83B400627E89E7300A01A2E /* PostMessageModel.swift in Sources */,
 				2517EC5C27E5A4520025E396 /* CredifyUserModel.swift in Sources */,
 				2517EC6A27E5A4520025E396 /* serviceXTheme.swift in Sources */,
 				2517EC3A27E5A4360025E396 /* UINavigationBar+Extension.swift in Sources */,
 				2517EC5A27E5A4520025E396 /* CredifyEnvs.swift in Sources */,
 				2517EC0027E57CED0025E396 /* Credify.docc in Sources */,
+				F83B400427E89DF200A01A2E /* PostMessageUtils.swift in Sources */,
 				2517EC6C27E5A4520025E396 /* Requests+Responses.swift in Sources */,
 				2517EC3B27E5A4360025E396 /* Dictionary+Extension.swift in Sources */,
 				2517EC5E27E5A4520025E396 /* serviceXConfig.swift in Sources */,

--- a/Credify.xcodeproj/project.pbxproj
+++ b/Credify.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		E0C17D0D9B8627E0F7DBC0A5 /* Pods_Credify.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C7A244039A269E07690C793C /* Pods_Credify.framework */; };
 		F83B400427E89DF200A01A2E /* PostMessageUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = F83B400327E89DF200A01A2E /* PostMessageUtils.swift */; };
 		F83B400627E89E7300A01A2E /* PostMessageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F83B400527E89E7300A01A2E /* PostMessageModel.swift */; };
+		F8AED25127E984780095DB6C /* PostMessageUtilsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AED25027E984780095DB6C /* PostMessageUtilsTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -108,6 +109,7 @@
 		EAE2E90792E6563322DB1C3E /* Pods-Credify-CredifyTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Credify-CredifyTests.debug.xcconfig"; path = "Target Support Files/Pods-Credify-CredifyTests/Pods-Credify-CredifyTests.debug.xcconfig"; sourceTree = "<group>"; };
 		F83B400327E89DF200A01A2E /* PostMessageUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostMessageUtils.swift; sourceTree = "<group>"; };
 		F83B400527E89E7300A01A2E /* PostMessageModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostMessageModel.swift; sourceTree = "<group>"; };
+		F8AED25027E984780095DB6C /* PostMessageUtilsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostMessageUtilsTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -176,6 +178,7 @@
 		2517EC0927E57CEE0025E396 /* CredifyTests */ = {
 			isa = PBXGroup;
 			children = (
+				F8AED24F27E9845E0095DB6C /* Utils */,
 				2517EC0A27E57CEE0025E396 /* CredifyTests.swift */,
 			);
 			path = CredifyTests;
@@ -310,6 +313,14 @@
 			);
 			name = Utils;
 			path = Credify/Utils;
+			sourceTree = "<group>";
+		};
+		F8AED24F27E9845E0095DB6C /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				F8AED25027E984780095DB6C /* PostMessageUtilsTest.swift */,
+			);
+			path = Utils;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -532,6 +543,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2517EC0B27E57CEE0025E396 /* CredifyTests.swift in Sources */,
+				F8AED25127E984780095DB6C /* PostMessageUtilsTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Credify/Credify/Extensions/Dictionary+Extension.swift
+++ b/Credify/Credify/Extensions/Dictionary+Extension.swift
@@ -43,7 +43,29 @@ extension Dictionary {
         }
     }
     
+    var jsonBase64: String {
+        let invalidJson = "Not a valid JSON"
+        do {
+            let jsonData = try JSONSerialization.data(withJSONObject: self)
+            return jsonData.base64EncodedString()
+        } catch {
+            return invalidJson
+        }
+    }
+    
     func jsonPresentation() {
         print(json)
+    }
+    
+    static func fromBase64(base64: String) -> Dictionary<String, Any>? {
+        guard let data = Data(base64Encoded: base64) else {
+            return nil
+        }
+        
+        do {
+            return try JSONSerialization.jsonObject(with: data, options: .mutableContainers) as? [String: Any]
+        } catch {
+            return nil
+        }
     }
 }

--- a/Credify/Credify/Objects/PostMessageModel.swift
+++ b/Credify/Credify/Objects/PostMessageModel.swift
@@ -1,0 +1,29 @@
+//
+//  PostMessageModel.swift
+//  Credify
+//
+//  Created by Gioan Le on 21/03/2022.
+//
+
+import Foundation
+import SwiftUI
+
+internal let ACTION_TYPE = "CREDIFY-MOBILE-SDK"
+
+internal enum PayloadType : String {
+    case base64 = "Base64"
+    case object = "Object"
+}
+
+internal enum SendMessageHandler: String {
+    case startRedemption
+    case pushClaimCompleted
+    case actionLogin
+}
+
+internal enum ReceiveMessageHandler: String {
+    case initialLoadCompleted
+    case createUserCompleted
+    case offerTransactionStatusChanged
+    case actionClose
+}

--- a/Credify/Credify/Utils/PostMessageUtils.swift
+++ b/Credify/Credify/Utils/PostMessageUtils.swift
@@ -1,0 +1,28 @@
+//
+//  PostMessageUtils.swift
+//  Credify
+//
+//  Created by Gioan Le on 21/03/2022.
+//
+
+import Foundation
+
+class PostMessageUtils {
+    static func parsePayload(dict: [String: Any]) -> [String: Any]? {
+        if dict.isEmpty {
+            return nil
+        }
+        
+        guard let payloadTypeStr = dict["payloadType"] as? String, let payloadType = PayloadType(rawValue: payloadTypeStr) else {
+            return dict["payload"] as? [String: Any]
+        }
+        
+        if payloadType == PayloadType.base64 {
+            guard let payload = dict["payload"] as? String else {
+                return nil
+            }
+            return Dictionary<String, Any>.fromBase64(base64: payload)
+        }
+        return dict["payload"] as? [String: Any]
+    }
+}

--- a/Credify/Credify/WebView/WebPresenter.swift
+++ b/Credify/Credify/WebView/WebPresenter.swift
@@ -30,7 +30,6 @@ enum PassportContext {
 }
 
 protocol WebPresenterProtocol {
-    var sendHandlers: [SendMessageHandler] { get }
     var receiveHandlers: [ReceiveMessageHandler] { get }
     func shouldClose(messageName: String) -> Bool
     func handleMessage(_: WKWebView, name: String, body: [String: Any]?)
@@ -45,14 +44,6 @@ class WebPresenter: WebPresenterProtocol {
     }
     
     private var offerTransactionStatus: RedemptionResult = .canceled
-    
-    var sendHandlers: [SendMessageHandler] {
-        return [
-            .actionLogin,
-            .pushClaimCompleted,
-            .startRedemption,
-        ]
-    }
     
     var receiveHandlers: [ReceiveMessageHandler] {
         return [

--- a/Credify/Credify/WebView/WebViewController.swift
+++ b/Credify/Credify/WebView/WebViewController.swift
@@ -30,7 +30,11 @@ class WebViewController: UIViewController {
         let configuration = WKWebViewConfiguration()
         let userController = WKUserContentController()
             
-        presenter.handlers.forEach { handler in
+        presenter.sendHandlers.forEach { handler in
+            userController.add(self, name: handler.rawValue)
+        }
+        
+        presenter.receiveHandlers.forEach { handler in
             userController.add(self, name: handler.rawValue)
         }
         
@@ -191,7 +195,7 @@ extension WebViewController: WKNavigationDelegate {
     
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         // NOTE: this is not working well
-        presenter.handleMessage(webView, name: MessageHandler.initialLoadCompleted.rawValue, body: nil)
+        presenter.handleMessage(webView, name: ReceiveMessageHandler.initialLoadCompleted.rawValue, body: nil)
     }
 }
 

--- a/Credify/Credify/WebView/WebViewController.swift
+++ b/Credify/Credify/WebView/WebViewController.swift
@@ -29,10 +29,6 @@ class WebViewController: UIViewController {
 
         let configuration = WKWebViewConfiguration()
         let userController = WKUserContentController()
-            
-        presenter.sendHandlers.forEach { handler in
-            userController.add(self, name: handler.rawValue)
-        }
         
         presenter.receiveHandlers.forEach { handler in
             userController.add(self, name: handler.rawValue)
@@ -194,7 +190,6 @@ extension WebViewController: WKUIDelegate {
 extension WebViewController: WKNavigationDelegate {
     
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        // NOTE: this is not working well
         presenter.handleMessage(webView, name: ReceiveMessageHandler.initialLoadCompleted.rawValue, body: nil)
     }
 }

--- a/CredifyTests/Utils/PostMessageUtilsTest.swift
+++ b/CredifyTests/Utils/PostMessageUtilsTest.swift
@@ -1,0 +1,57 @@
+//
+//  PostMessageUtilsTest.swift
+//  CredifyTests
+//
+//  Created by Gioan Le on 22/03/2022.
+//
+
+import Foundation
+import XCTest
+@testable import Credify
+
+class PostMessageUtilsTest : XCTestCase {
+    func testParseBase64Payload() throws {
+        // Raw data
+        // let expectedResult: [String: Any] = [
+        //    "data":"This is the payload"
+        // ]
+        let expectedKey = "data"
+        let expectedValue = "This is the payload"
+        
+        
+        let dict: [String: Any] = [
+            "action": "actionLogin",
+            "payloadType": "Base64",
+            "payload": "eyJkYXRhIjoiVGhpcyBpcyB0aGUgcGF5bG9hZCJ9"
+        ]
+        
+        let result = PostMessageUtils.parsePayload(dict: dict)
+        
+        assert(result!.contains(where: { (key: String, value: Any) in
+            key == expectedKey && (value as! String) == expectedValue
+        }))
+    }
+    
+    func testParseNotBase64Payload() throws {
+        // Raw data
+        // let expectedResult: [String: Any] = [
+        //    "data":"This is the payload"
+        // ]
+        let expectedKey = "data"
+        let expectedValue = "This is the payload"
+        
+        
+        let dict: [String: Any] = [
+            "action": "actionLogin",
+            "payload": [
+                "data": "This is the payload"
+            ]
+        ]
+        
+        let result = PostMessageUtils.parsePayload(dict: dict)
+        
+        assert(result!.contains(where: { (key: String, value: Any) in
+            key == expectedKey && (value as! String) == expectedValue
+        }))
+    }
+}

--- a/ExampleApp/ExampleApp/ViewController.swift
+++ b/ExampleApp/ExampleApp/ViewController.swift
@@ -69,7 +69,13 @@ class ViewController: UIViewController {
         }
     }
     @IBAction func clickButton(_ sender: Any) {
-        startOffer(offerList[1])
+        let offers = offerList.filter { offer in
+            !offer.campaign.useReferral
+        }
+        
+        if !offers.isEmpty {
+            startOffer(offers[0])
+        }
     }
     
 }


### PR DESCRIPTION
## Description
- Added code to encode base64 for the message payload for sending and decode for receiving message.
- Corrected the messages with the same structure.

## Motivation & Context
Ticket: https://app.shortcut.com/credify/story/21728/feature-ios-encode-base64-for-the-posting-message-payload

## How has this been tested?
Test offer redemption flow on Web(normal and market proxy) and iOS

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.