### PR TITLE
Using Credify colors by default [21818]

### DIFF
--- a/Credify/Credify/Extensions/UIColor+Extension.swift
+++ b/Credify/Credify/Extensions/UIColor+Extension.swift
@@ -44,11 +44,11 @@ extension Extension where Base: UIColor {
     }
     
     static var primary: String {
-        return "#1382F8"
+        return "#AB2185"
     }
     
     static var primaryDarker: String {
-        return "#17A6EF"
+        return "#5A24B3"
     }
     
     static var text: String {
@@ -72,7 +72,7 @@ extension Extension where Base: UIColor {
     }
     
     static var secondaryActive: String {
-        return "#1483F7"
+        return "#9147D7"
     }
     
     static var secondaryDisable: String {
@@ -88,11 +88,11 @@ extension Extension where Base: UIColor {
     }
     
     static var primaryButtonBrandyStart: String {
-        return "#02D15D"
+        return "#AB2185"
     }
     
     static var primaryButtonBrandyEnd: String {
-        return "#01B779"
+        return "#5A24B3"
     }
     
     static var primaryIconColor: String {

--- a/Credify/Credify/Theme/ThemeColor.swift
+++ b/Credify/Credify/Theme/ThemeColor.swift
@@ -97,7 +97,7 @@ public struct ThemeColor : Codable {
             secondaryActive: UIColor.ex.secondaryActive,
             secondaryDisable: UIColor.ex.secondaryDisable,
             secondaryText: UIColor.ex.secondaryText,
-            secondaryComponentBackground: UIColor.ex.backgroundLight,
+            secondaryComponentBackground: UIColor.ex.backgroundComponent,
             secondaryBackground: UIColor.ex.backgroundLight,
             primaryButtonTextColor: UIColor.ex.primaryButtonTextColor,
             primaryButtonBrandyStart: UIColor.ex.primaryButtonBrandyStart,

--- a/Credify/Credify/Theme/ThemeFont.swift
+++ b/Credify/Credify/Theme/ThemeFont.swift
@@ -88,8 +88,8 @@ public struct ThemeFont : Codable {
     }
     
     public static var `default`: ThemeFont {
-        return ThemeFont(primaryFontFamily: "Roboto",
-                         secondaryFontFamily: "Roboto",
+        return ThemeFont(primaryFontFamily: "Oswald",
+                         secondaryFontFamily: "Roboto Slab",
                          bigTitleFontSize: 21,
                          bigTitleFontLineHeight: 31,
                          modelTitleFontSize: 20,

--- a/Credify/Credify/WebView/WebViewController.swift
+++ b/Credify/Credify/WebView/WebViewController.swift
@@ -25,6 +25,10 @@ class WebViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        if #available(iOS 13.0, *) {
+            overrideUserInterfaceStyle = .light
+        }
+        
         customizeNavBar()
 
         let configuration = WKWebViewConfiguration()


### PR DESCRIPTION
## Description
- Using Credify color by default for UI customization.

## Motivation & Context
Ticket: https://app.shortcut.com/credify/story/21818/web-bug-using-credify-colors-by-default

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.