### PR TITLE
Old user still is cached in the passport app [21895]

### DIFF
--- a/Credify/Credify/Objects/AppState.swift
+++ b/Credify/Credify/Objects/AppState.swift
@@ -14,7 +14,6 @@ class AppState {
     
     var config: serviceXConfig? = nil
     
-    var credifyId: String? = nil
     var user: CredifyUserModel? = nil
     var pushClaimTokensTask: ((String, ((Bool) -> Void)?) -> Void)? = nil
     var redemptionResult: ((RedemptionResult) -> Void)? = nil

--- a/Credify/Credify/WebView/WebPresenter.swift
+++ b/Credify/Credify/WebView/WebPresenter.swift
@@ -130,8 +130,6 @@ class WebPresenter: WebPresenterProtocol {
                 self.postPushedClaimMessage(webView, isSuccess: false)
                 return
             }
-            
-            AppState.shared.credifyId = credifyId
 
             task(credifyId) { result in
                 self.postPushedClaimMessage(webView, isSuccess: result)

--- a/Credify/Credify/serviceX.swift
+++ b/Credify/Credify/serviceX.swift
@@ -106,14 +106,10 @@ public struct serviceX {
             
             // All are valid
             if errorMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                var u = userProfile
                 AppState.shared.pushClaimTokensTask = pushClaimTokensTask
                 AppState.shared.redemptionResult = completionHandler
-                if (userProfile.credifyId ?? "").isEmpty {
-                    u.credifyId = AppState.shared.credifyId
-                }
                 
-                let context = PassportContext.offer(offer: offer, user: u)
+                let context = PassportContext.offer(offer: offer, user: userProfile)
                 let vc = WebViewController.instantiate(context: context)
                 let navigationController = UINavigationController(rootViewController: vc)
                 navigationController.modalPresentationStyle = .overFullScreen
@@ -167,9 +163,6 @@ public struct serviceX {
                                    completionHandler: @escaping (RedemptionResult) -> Void) {
             AppState.shared.pushClaimTokensTask = pushClaimTokensTask
             AppState.shared.redemptionResult = completionHandler
-            if (AppState.shared.credifyId ?? "").isEmpty {
-                AppState.shared.credifyId = userProfile.credifyId
-            }
             
             let context = PassportContext.bnpl(offer: offer, user: userProfile, orderId: orderId)
             let vc = WebViewController.instantiate(context: context)


### PR DESCRIPTION
## Description
- Fixed this issue by removing the `credifyId` in the `AppState` object. That's mean the SDK will use `credifyId` that was passed by the caller.

## Motivation & Context
Ticket: https://app.shortcut.com/credify/story/21895/ios-sdk-bug-old-user-still-is-cached-in-the-passport-app

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
