### PR TITLE
Hide back button in some cases [22287]

### DIFF
--- a/Credify.xcodeproj/project.pbxproj
+++ b/Credify.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		F862448327FE6C59002C85F8 /* EntitiesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F862448227FE6C59002C85F8 /* EntitiesTest.swift */; };
 		F862448527FE6DC6002C85F8 /* OrganizationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F862448427FE6DC6002C85F8 /* OrganizationUseCase.swift */; };
 		F8AED25127E984780095DB6C /* PostMessageUtilsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AED25027E984780095DB6C /* PostMessageUtilsTest.swift */; };
+		F8E9FFA628068C2400F25B59 /* CommonModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E9FFA528068C2400F25B59 /* CommonModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -120,6 +121,7 @@
 		F862448227FE6C59002C85F8 /* EntitiesTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EntitiesTest.swift; sourceTree = "<group>"; };
 		F862448427FE6DC6002C85F8 /* OrganizationUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrganizationUseCase.swift; sourceTree = "<group>"; };
 		F8AED25027E984780095DB6C /* PostMessageUtilsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostMessageUtilsTest.swift; sourceTree = "<group>"; };
+		F8E9FFA528068C2400F25B59 /* CommonModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CommonModel.swift; path = Credify/Credify/Objects/CommonModel.swift; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -231,6 +233,7 @@
 			isa = PBXGroup;
 			children = (
 				2517EC4427E5A4520025E396 /* WebPresenter.swift */,
+				F8E9FFA528068C2400F25B59 /* CommonModel.swift */,
 				2517EC4527E5A4520025E396 /* WebViewController.swift */,
 			);
 			name = WebView;
@@ -535,6 +538,7 @@
 			files = (
 				2517EC6027E5A4520025E396 /* WebViewController.swift in Sources */,
 				2517EC3927E5A4360025E396 /* Extension.swift in Sources */,
+				F8E9FFA628068C2400F25B59 /* CommonModel.swift in Sources */,
 				2517EC3827E5A4360025E396 /* String+Extension.swift in Sources */,
 				F84828B827EAE8BC00ED1E12 /* UIUtils.swift in Sources */,
 				2517EC2327E5A3B40025E396 /* serviceX.swift in Sources */,

--- a/Credify/Credify/Constants.swift
+++ b/Credify/Credify/Constants.swift
@@ -37,4 +37,48 @@ struct Constants {
             return "https://passport.credify.one"
         }
     }
+    
+    /// Offer
+    internal static var OFFER_SHOWING_CLOSE_BUTTON_URLS: [String] {
+        let webUrl = WEB_URL
+        
+        return [
+            "\(webUrl)/bad-request",
+            "\(webUrl)/initial",
+            "\(webUrl)/redeem-success",
+            "\(webUrl)/canceled-offer",
+            "\(webUrl)/vib-offer-referral",
+            "\(webUrl)/ocb-offer-referral",
+        ]
+    }
+    
+    /// BNPL
+    internal static var BNPL_SHOWING_CLOSE_BUTTON_URLS: [String] {
+        let webUrl = WEB_URL
+        
+        return [
+            "\(webUrl)/bnpl/bad-request",
+        ]
+    }
+    
+    /// My page
+    internal static var MY_PAGE_SHOWING_CLOSE_BUTTON_URLS: [String] {
+        let webUrl = WEB_URL
+        
+        return [
+            "\(webUrl)/login",
+            "\(webUrl)/bad-request",
+        ]
+    }
+    
+    /// Service Instance
+    internal static var SERVICE_INSTANCE_SHOWING_CLOSE_BUTTON_URLS: [String] {
+        let webUrl = WEB_URL
+        
+        return [
+            "\(webUrl)/login",
+            "\(webUrl)/bad-request",
+            "\(webUrl)/service-instance",
+        ]
+    }
 }

--- a/ExampleApp/ExampleApp/ViewController.swift
+++ b/ExampleApp/ExampleApp/ViewController.swift
@@ -88,7 +88,10 @@ class ViewController: UIViewController {
             from: self,
             user: user,
             marketId: MARKET_ID,
-            productTypes: [ProductType.autoMobileInsurance]
-        )
+            productTypes: [ProductType.autoMobileInsurance]) { [weak self] in
+                self?.dismiss(animated: true) {
+                    print("Done")
+                }
+            }
     }
 }


### PR DESCRIPTION
## Description
The `back` and `close` will be showed/hidden that depend on the current page. 
Normal offer:
- Showing the `close` button in the below page: `/bad-request`, `/initial`, `/redeem-success`, `/canceled-offer`, `/vib-offer-referral`, `/ocb-offer-referral`.
- The other pages will show the `back` button except the Pending offer page(`/pending-offer`).

BNPL
- Showing the `close` button in the below page: `bnpl/bad-request`, `/bnpl`
- The other pages will show the `back` button.

Show Passport
- Showing the `close` button in the below page: `/bad-request`, `/login`, `/`
- The other pages will show the `back` button.

Show Passport
- Showing the `close` button in the below page: `/bad-request`, `/login`, `/service-instance`
- The other pages will show the `back` button.

## Motivation & Context
Ticket: https://app.shortcut.com/credify/story/22287/feature-ios-servicex-hide-back-button-in-some-cases

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.