### PR TITLE
Don't allow to click buttons on nav bar when having loading in web app [22944]

### DIFF
--- a/Credify/Credify/WebView/WebPresenter.swift
+++ b/Credify/Credify/WebView/WebPresenter.swift
@@ -309,12 +309,12 @@ class WebPresenter: WebPresenterProtocol {
     
     func isLoading(webView: WKWebView, onResult: @escaping (Bool) -> Void) {
         webView.evaluateJavaScript("document.getElementById('\(LOADING_COMPONENT_ID)') !== null") { result, error in
-            guard let hasLoading = result as? Bool else {
+            guard let isLoading = result as? Bool else {
                 onResult(false)
                 return
             }
             
-            onResult(hasLoading)
+            onResult(isLoading)
         }
     }
     

--- a/Credify/Credify/WebView/WebPresenter.swift
+++ b/Credify/Credify/WebView/WebPresenter.swift
@@ -44,10 +44,12 @@ protocol WebPresenterProtocol {
     func isBackButtonVisible(urlObj: URL?) -> Bool
     func isCloseButtonVisible(urlObj: URL?) -> Bool
     func doPostMessageForLoggingIn(webView: WKWebView)
-    func checkWebPageHasLoading(webView: WKWebView, onResult: @escaping (Bool) -> Void)
+    func isLoading(webView: WKWebView, onResult: @escaping (Bool) -> Void)
 }
 
 class WebPresenter: WebPresenterProtocol {
+    private let LOADING_COMPONENT_ID = "credify-main-loading-component"
+    
     private let context: PassportContext
     
     init(context: PassportContext) {
@@ -305,8 +307,8 @@ class WebPresenter: WebPresenterProtocol {
         }
     }
     
-    func checkWebPageHasLoading(webView: WKWebView, onResult: @escaping (Bool) -> Void) {
-        webView.evaluateJavaScript("document.getElementById('credify-main-loading-component') !== null") { result, error in
+    func isLoading(webView: WKWebView, onResult: @escaping (Bool) -> Void) {
+        webView.evaluateJavaScript("document.getElementById('\(LOADING_COMPONENT_ID)') !== null") { result, error in
             guard let hasLoading = result as? Bool else {
                 onResult(false)
                 return

--- a/Credify/Credify/WebView/WebPresenter.swift
+++ b/Credify/Credify/WebView/WebPresenter.swift
@@ -44,6 +44,7 @@ protocol WebPresenterProtocol {
     func isBackButtonVisible(urlObj: URL?) -> Bool
     func isCloseButtonVisible(urlObj: URL?) -> Bool
     func doPostMessageForLoggingIn(webView: WKWebView)
+    func checkWebPageHasLoading(webView: WKWebView, onResult: @escaping (Bool) -> Void)
 }
 
 class WebPresenter: WebPresenterProtocol {
@@ -301,6 +302,17 @@ class WebPresenter: WebPresenterProtocol {
     func doPostMessageForLoggingIn(webView: WKWebView) {
         if "\(Constants.WEB_URL)/login".starts(with: (webView.url?.absoluteString ?? "")) {
             handleMessage(webView, name: ReceiveMessageHandler.initialLoadCompleted.rawValue, body: nil)
+        }
+    }
+    
+    func checkWebPageHasLoading(webView: WKWebView, onResult: @escaping (Bool) -> Void) {
+        webView.evaluateJavaScript("document.getElementById('credify-main-loading-component') !== null") { result, error in
+            guard let hasLoading = result as? Bool else {
+                onResult(false)
+                return
+            }
+            
+            onResult(hasLoading)
         }
     }
     

--- a/Credify/Credify/WebView/WebViewController.swift
+++ b/Credify/Credify/WebView/WebViewController.swift
@@ -163,7 +163,7 @@ class WebViewController: UIViewController {
     }
     
     @objc private func goBack() {
-        presenter.checkWebPageHasLoading(webView: webView) { hasLoading in
+        presenter.isLoading(webView: webView) { hasLoading in
             if !hasLoading && self.webView.canGoBack  {
                 self.webView.goBack()
             }
@@ -171,7 +171,7 @@ class WebViewController: UIViewController {
     }
     
     @objc private func close() {
-        presenter.checkWebPageHasLoading(webView: webView) { hasLoading in
+        presenter.isLoading(webView: webView) { hasLoading in
             if !hasLoading {
                 self.dismiss(animated: true) {
                     self.presenter.hanldeCompletionHandler()

--- a/Credify/Credify/WebView/WebViewController.swift
+++ b/Credify/Credify/WebView/WebViewController.swift
@@ -163,14 +163,20 @@ class WebViewController: UIViewController {
     }
     
     @objc private func goBack() {
-        if webView.canGoBack {
-            webView.goBack()
+        presenter.checkWebPageHasLoading(webView: webView) { hasLoading in
+            if !hasLoading && self.webView.canGoBack  {
+                self.webView.goBack()
+            }
         }
     }
     
     @objc private func close() {
-        dismiss(animated: true) {
-            self.presenter.hanldeCompletionHandler()
+        presenter.checkWebPageHasLoading(webView: webView) { hasLoading in
+            if !hasLoading {
+                self.dismiss(animated: true) {
+                    self.presenter.hanldeCompletionHandler()
+                }
+            }
         }
     }
 

--- a/Credify/Credify/WebView/WebViewController.swift
+++ b/Credify/Credify/WebView/WebViewController.swift
@@ -163,16 +163,16 @@ class WebViewController: UIViewController {
     }
     
     @objc private func goBack() {
-        presenter.isLoading(webView: webView) { hasLoading in
-            if !hasLoading && self.webView.canGoBack  {
+        presenter.isLoading(webView: webView) { isLoading in
+            if !isLoading && self.webView.canGoBack  {
                 self.webView.goBack()
             }
         }
     }
     
     @objc private func close() {
-        presenter.isLoading(webView: webView) { hasLoading in
-            if !hasLoading {
+        presenter.isLoading(webView: webView) { isLoading in
+            if !isLoading {
                 self.dismiss(animated: true) {
                     self.presenter.hanldeCompletionHandler()
                 }


### PR DESCRIPTION
## Description
The SDK will check if there is loading component that is visible on the UI then don't allow the user to go back or close this page

## Motivation & Context
Ticket: https://app.shortcut.com/credify/story/22944/feature-ios-don-t-allow-to-click-buttons-on-nav-bar-when-having-loading-in-web-app

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.