### PR TITLE
Move paths(web pages) from the SDKs to the passport app  [23033]

### DIFF
--- a/Credify/Credify/Constants.swift
+++ b/Credify/Credify/Constants.swift
@@ -51,34 +51,4 @@ struct Constants {
             "\(webUrl)/ocb-offer-referral",
         ]
     }
-    
-    /// BNPL
-    internal static var BNPL_SHOWING_CLOSE_BUTTON_URLS: [String] {
-        let webUrl = WEB_URL
-        
-        return [
-            "\(webUrl)/bnpl/bad-request",
-        ]
-    }
-    
-    /// My page
-    internal static var MY_PAGE_SHOWING_CLOSE_BUTTON_URLS: [String] {
-        let webUrl = WEB_URL
-        
-        return [
-            "\(webUrl)/login",
-            "\(webUrl)/bad-request",
-        ]
-    }
-    
-    /// Service Instance
-    internal static var SERVICE_INSTANCE_SHOWING_CLOSE_BUTTON_URLS: [String] {
-        let webUrl = WEB_URL
-        
-        return [
-            "\(webUrl)/login",
-            "\(webUrl)/bad-request",
-            "\(webUrl)/service-instance",
-        ]
-    }
 }

--- a/Credify/Credify/Objects/AppState.swift
+++ b/Credify/Credify/Objects/AppState.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class AppState {
+internal class AppState {
     static let shared = AppState()
     
     private init() {}
@@ -20,4 +20,16 @@ class AppState {
     var redemptionResult: ((RedemptionResult) -> Void)? = nil
     var dismissCompletion: (() -> Void)? = nil
     var bnplRedemptionResult: ((_ status: RedemptionResult,_ orderId: String,_ isPaymentCompleted: Bool) -> Void)? = nil
+    
+    /// Offer: for show/hide the close and back buttons
+    var offerShowingCloseButtonUrls: [String] = []
+    
+    /// BNPL: for show/hide the close and back buttons
+    var bnplShowingCloseButtonUrls: [String] = []
+    
+    /// My page: for show/hide the close and back buttons
+    var myPageShowingCloseButtonUrls: [String] = []
+    
+    /// Service Instance: for show/hide the close and back buttons
+    var serviceInstanceShowingCloseButtonUrls: [String] = []
 }

--- a/Credify/Credify/Objects/PostMessageModel.swift
+++ b/Credify/Credify/Objects/PostMessageModel.swift
@@ -27,6 +27,7 @@ internal enum ReceiveMessageHandler: String {
     case offerTransactionStatusChanged
     case actionClose
     case bnplPaymentComplete
+    case sendPathsForShowingCloseButton
 }
 
 internal class StartBnplMessage: Codable {


### PR DESCRIPTION
## Description
Moved the paths that are for checking to show/hide back/close buttons from the SDKs to the passport app. Once the mobile SDKs loaded the web app. The web app will post a message to send these paths to the mobile SDKs.

## Motivation & Context
Ticket: https://app.shortcut.com/credify/story/23033/mobile-move-paths-web-pages-from-the-sdks-to-the-passport-app

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.