### PR TITLE
Med247 app - Passport's background does not fit with height of Med247 app [23462]

### DIFF
--- a/Credify/Credify/WebView/WebViewController.swift
+++ b/Credify/Credify/WebView/WebViewController.swift
@@ -25,6 +25,11 @@ class WebViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        // 23462: Med247 app - Passport's background does not fit with height of Med247 app
+        let theme = AppState.shared.config?.theme
+        let themeColor = theme?.color
+        view.backgroundColor = UIColor.fromHex(themeColor?.secondaryBackground ?? "#FFFFFF")
+        
         if #available(iOS 13.0, *) {
             overrideUserInterfaceStyle = .light
         }


### PR DESCRIPTION
## Description
- Set background color for the View Controller. The color will be get from theme or it's white color by default.

## Motivation & Context
Ticket: https://app.shortcut.com/credify/story/23462/ios-med247-app-passport-s-background-does-not-fit-with-height-of-med247-app

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.