### PR TITLE
Passport of redeemed list- Start over link on a pending offer [24002]

### DIFF
--- a/Credify.xcodeproj/project.pbxproj
+++ b/Credify.xcodeproj/project.pbxproj
@@ -53,6 +53,8 @@
 		F862448327FE6C59002C85F8 /* EntitiesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F862448227FE6C59002C85F8 /* EntitiesTest.swift */; };
 		F862448527FE6DC6002C85F8 /* OrganizationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F862448427FE6DC6002C85F8 /* OrganizationUseCase.swift */; };
 		F8AED25127E984780095DB6C /* PostMessageUtilsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AED25027E984780095DB6C /* PostMessageUtilsTest.swift */; };
+		F8C445E42840EDE700310CDF /* WebViewUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C445E22840EDE700310CDF /* WebViewUtils.swift */; };
+		F8C445E52840EDE700310CDF /* ValidationUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C445E32840EDE700310CDF /* ValidationUtils.swift */; };
 		F8E9FFA628068C2400F25B59 /* CommonModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E9FFA528068C2400F25B59 /* CommonModel.swift */; };
 /* End PBXBuildFile section */
 
@@ -121,6 +123,8 @@
 		F862448227FE6C59002C85F8 /* EntitiesTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EntitiesTest.swift; sourceTree = "<group>"; };
 		F862448427FE6DC6002C85F8 /* OrganizationUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrganizationUseCase.swift; sourceTree = "<group>"; };
 		F8AED25027E984780095DB6C /* PostMessageUtilsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostMessageUtilsTest.swift; sourceTree = "<group>"; };
+		F8C445E22840EDE700310CDF /* WebViewUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebViewUtils.swift; sourceTree = "<group>"; };
+		F8C445E32840EDE700310CDF /* ValidationUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValidationUtils.swift; sourceTree = "<group>"; };
 		F8E9FFA528068C2400F25B59 /* CommonModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CommonModel.swift; path = Credify/Credify/Objects/CommonModel.swift; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
@@ -325,6 +329,8 @@
 		F83B400227E89DF200A01A2E /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				F8C445E32840EDE700310CDF /* ValidationUtils.swift */,
+				F8C445E22840EDE700310CDF /* WebViewUtils.swift */,
 				F83B400327E89DF200A01A2E /* PostMessageUtils.swift */,
 				F84828B727EAE8BC00ED1E12 /* UIUtils.swift */,
 			);
@@ -548,6 +554,7 @@
 				2517EC5B27E5A4520025E396 /* Entities.swift in Sources */,
 				F83B400627E89E7300A01A2E /* PostMessageModel.swift in Sources */,
 				2517EC5C27E5A4520025E396 /* CredifyUserModel.swift in Sources */,
+				F8C445E52840EDE700310CDF /* ValidationUtils.swift in Sources */,
 				2517EC6A27E5A4520025E396 /* serviceXTheme.swift in Sources */,
 				2517EC3A27E5A4360025E396 /* UINavigationBar+Extension.swift in Sources */,
 				2517EC5A27E5A4520025E396 /* CredifyEnvs.swift in Sources */,
@@ -561,6 +568,7 @@
 				2517EC3727E5A4360025E396 /* UIViewController+Extension.swift in Sources */,
 				2517EC5D27E5A4520025E396 /* CredifyError.swift in Sources */,
 				2517EC6827E5A4520025E396 /* ThemeFont.swift in Sources */,
+				F8C445E42840EDE700310CDF /* WebViewUtils.swift in Sources */,
 				2517EC5F27E5A4520025E396 /* WebPresenter.swift in Sources */,
 				2517EC3527E5A4360025E396 /* UIColor+Extension.swift in Sources */,
 				2517EC6B27E5A4520025E396 /* APIClient.swift in Sources */,

--- a/Credify.xcodeproj/project.pbxproj
+++ b/Credify.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		F83B400627E89E7300A01A2E /* PostMessageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F83B400527E89E7300A01A2E /* PostMessageModel.swift */; };
 		F84828B227EADC9200ED1E12 /* serviceX.strings in Resources */ = {isa = PBXBuildFile; fileRef = F84828B027EADC9200ED1E12 /* serviceX.strings */; };
 		F84828B827EAE8BC00ED1E12 /* UIUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84828B727EAE8BC00ED1E12 /* UIUtils.swift */; };
+		F85DCD0F2841AAAE00A93B56 /* LocaleUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = F85DCD0E2841AAAE00A93B56 /* LocaleUtils.swift */; };
 		F862448327FE6C59002C85F8 /* EntitiesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F862448227FE6C59002C85F8 /* EntitiesTest.swift */; };
 		F862448527FE6DC6002C85F8 /* OrganizationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F862448427FE6DC6002C85F8 /* OrganizationUseCase.swift */; };
 		F8AED25127E984780095DB6C /* PostMessageUtilsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AED25027E984780095DB6C /* PostMessageUtilsTest.swift */; };
@@ -120,6 +121,7 @@
 		F84828B327EADCA200ED1E12 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = Credify/ja.lproj/serviceX.strings; sourceTree = "<group>"; };
 		F84828B427EADCB300ED1E12 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = Credify/vi.lproj/serviceX.strings; sourceTree = "<group>"; };
 		F84828B727EAE8BC00ED1E12 /* UIUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIUtils.swift; sourceTree = "<group>"; };
+		F85DCD0E2841AAAE00A93B56 /* LocaleUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocaleUtils.swift; sourceTree = "<group>"; };
 		F862448227FE6C59002C85F8 /* EntitiesTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EntitiesTest.swift; sourceTree = "<group>"; };
 		F862448427FE6DC6002C85F8 /* OrganizationUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrganizationUseCase.swift; sourceTree = "<group>"; };
 		F8AED25027E984780095DB6C /* PostMessageUtilsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostMessageUtilsTest.swift; sourceTree = "<group>"; };
@@ -329,6 +331,7 @@
 		F83B400227E89DF200A01A2E /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				F85DCD0E2841AAAE00A93B56 /* LocaleUtils.swift */,
 				F8C445E32840EDE700310CDF /* ValidationUtils.swift */,
 				F8C445E22840EDE700310CDF /* WebViewUtils.swift */,
 				F83B400327E89DF200A01A2E /* PostMessageUtils.swift */,
@@ -543,6 +546,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2517EC6027E5A4520025E396 /* WebViewController.swift in Sources */,
+				F85DCD0F2841AAAE00A93B56 /* LocaleUtils.swift in Sources */,
 				2517EC3927E5A4360025E396 /* Extension.swift in Sources */,
 				F8E9FFA628068C2400F25B59 /* CommonModel.swift in Sources */,
 				2517EC3827E5A4360025E396 /* String+Extension.swift in Sources */,

--- a/Credify/Credify/Extensions/String+Extension.swift
+++ b/Credify/Credify/Extensions/String+Extension.swift
@@ -24,6 +24,13 @@ extension String {
         }
         // Concept Language IDs:
         // https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPInternational/LanguageandLocaleIDs/LanguageandLocaleIDs.html#//apple_ref/doc/uid/10000171i-CH15
+        // 24002: Passport of redeemed list- Start over link on a pending offer
+        if let language = AppState.shared.language,
+           let languagePath = bundle.path(forResource: language, ofType: "lproj"),
+           let languageBundle = Bundle(path: languagePath) {
+            return NSLocalizedString(self, tableName: tableName, bundle: languageBundle, value:dv, comment: "")
+        }
+            
         if let deviceLanguage = Locale.preferredLanguages.first?.split(separator: "-").first,
            let languagePath = bundle.path(forResource: String(deviceLanguage), ofType: "lproj"),
            let languageBundle = Bundle(path: languagePath) {

--- a/Credify/Credify/Extensions/String+Extension.swift
+++ b/Credify/Credify/Extensions/String+Extension.swift
@@ -25,14 +25,8 @@ extension String {
         // Concept Language IDs:
         // https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPInternational/LanguageandLocaleIDs/LanguageandLocaleIDs.html#//apple_ref/doc/uid/10000171i-CH15
         // 24002: Passport of redeemed list- Start over link on a pending offer
-        if let language = AppState.shared.language,
-           let languagePath = bundle.path(forResource: language, ofType: "lproj"),
-           let languageBundle = Bundle(path: languagePath) {
-            return NSLocalizedString(self, tableName: tableName, bundle: languageBundle, value:dv, comment: "")
-        }
-            
-        if let deviceLanguage = Locale.preferredLanguages.first?.split(separator: "-").first,
-           let languagePath = bundle.path(forResource: String(deviceLanguage), ofType: "lproj"),
+        if let languageCode = LocaleUtils.languageCode,
+           let languagePath = bundle.path(forResource: languageCode, ofType: "lproj"),
            let languageBundle = Bundle(path: languagePath) {
             return NSLocalizedString(self, tableName: tableName, bundle: languageBundle, value:dv, comment: "")
         }

--- a/Credify/Credify/Extensions/String+Extension.swift
+++ b/Credify/Credify/Extensions/String+Extension.swift
@@ -38,4 +38,10 @@ extension String {
         }
         return NSLocalizedString(self, tableName: tableName, bundle: bundle, value: dv, comment: "")
     }
+    
+    var isBlankOrEmpty: Bool {
+        get {
+            return self.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+    }
 }

--- a/Credify/Credify/Objects/AppState.swift
+++ b/Credify/Credify/Objects/AppState.swift
@@ -32,4 +32,6 @@ internal class AppState {
     
     /// Service Instance: for show/hide the close and back buttons
     var serviceInstanceShowingCloseButtonUrls: [String] = []
+    
+    var language: String? = nil
 }

--- a/Credify/Credify/Objects/AppState.swift
+++ b/Credify/Credify/Objects/AppState.swift
@@ -33,5 +33,5 @@ internal class AppState {
     /// Service Instance: for show/hide the close and back buttons
     var serviceInstanceShowingCloseButtonUrls: [String] = []
     
-    var language: String? = nil
+    var language: Language? = nil
 }

--- a/Credify/Credify/Objects/CredifyUserModel.swift
+++ b/Credify/Credify/Objects/CredifyUserModel.swift
@@ -37,10 +37,7 @@ public struct CredifyUserModel: Codable {
     }
     
     public var isLastNameComesFirst: Bool {
-//        if Locale.languageSupportLastFirstNameOrder.contains(CoreService.config.locale.code) {
-//            return true
-//        }
-        return true
+        return LocaleUtils.isShowLastFirstNameOrder
     }
     
     public var localizedName: String {

--- a/Credify/Credify/Objects/Entities.swift
+++ b/Credify/Credify/Objects/Entities.swift
@@ -350,3 +350,9 @@ public struct BNPLOfferInfo : Codable {
         case credifyId = "credify_id"
     }
 }
+
+public enum Language : String {
+    case vietnamese = "vi"
+    case japanese = "ja"
+    case english = "en"
+}

--- a/Credify/Credify/Objects/PostMessageModel.swift
+++ b/Credify/Credify/Objects/PostMessageModel.swift
@@ -28,6 +28,7 @@ internal enum ReceiveMessageHandler: String {
     case actionClose
     case bnplPaymentComplete
     case sendPathsForShowingCloseButton
+    case loginLoadCompleted
 }
 
 internal class StartBnplMessage: Codable {

--- a/Credify/Credify/Utils/LocaleUtils.swift
+++ b/Credify/Credify/Utils/LocaleUtils.swift
@@ -1,0 +1,37 @@
+//
+//  LocaleUtils.swift
+//  
+//
+//  Created by Gioan Le on 28/05/2022.
+//
+
+import Foundation
+
+class LocaleUtils {
+    static let languageSupportLastFirstNameOrder = ["vi", "ja"]
+    
+    static var languageCode: String? {
+        get {
+            // From client setting
+            if let language = AppState.shared.language {
+                return language.rawValue
+            }
+            
+            // From device
+            if let deviceLanguage = Locale.preferredLanguages.first?.split(separator: "-").first {
+                return String(deviceLanguage)
+            }
+            
+            return nil
+        }
+    }
+    
+    static var isShowLastFirstNameOrder: Bool {
+        get {
+            if let languageCode = languageCode {
+                return languageSupportLastFirstNameOrder.contains(languageCode)
+            }
+            return false
+        }
+    }
+}

--- a/Credify/Credify/Utils/ValidationUtils.swift
+++ b/Credify/Credify/Utils/ValidationUtils.swift
@@ -15,7 +15,7 @@ class ValidationUtils {
         return !trimmedCountryCode.isEmpty && trimmedNumber.count >= 8 && trimmedNumber.count <= 12
     }
     
-    static func canShowMyPage(from: UIViewController, user: CredifyUserModel) -> Bool {
+    static func showErrorIfShowMyPageFails(from: UIViewController, user: CredifyUserModel) -> Bool {
         let tableName = "serviceX"
         var errorMessage = ""
         
@@ -38,7 +38,7 @@ class ValidationUtils {
         return true
     }
     
-    static func canShowDetailPage(from: UIViewController, user: CredifyUserModel, marketId: String) -> Bool {
+    static func showErrorIfShowDetailPageFails(from: UIViewController, user: CredifyUserModel, marketId: String) -> Bool {
         let tableName = "serviceX"
         var errorMessage = ""
         
@@ -67,7 +67,7 @@ class ValidationUtils {
         return true
     }
     
-    static func checkBNPLAvailable(
+    static func showErrorIfBNPLUnavailable(
         from: UIViewController,
         offers: [OfferData],
         providers: [Organization]
@@ -89,7 +89,7 @@ class ValidationUtils {
         return true
     }
     
-    static func canStartToRedeemOffer(from: UIViewController, user: CredifyUserModel) -> Bool {
+    static func showErrorIfOfferCannotStart(from: UIViewController, user: CredifyUserModel) -> Bool {
         let tableName = "serviceX"
         var errorMessage = ""
         

--- a/Credify/Credify/Utils/ValidationUtils.swift
+++ b/Credify/Credify/Utils/ValidationUtils.swift
@@ -1,0 +1,120 @@
+//
+//  ValidationUtils.swift
+//  
+//
+//  Created by Gioan Le on 27/05/2022.
+//
+
+import Foundation
+import UIKit
+
+class ValidationUtils {
+    static func isPhoneValid(countryCode: String, phoneNumber: String) -> Bool {
+        let trimmedCountryCode = countryCode.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedNumber = phoneNumber.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !trimmedCountryCode.isEmpty && trimmedNumber.count >= 8 && trimmedNumber.count <= 12
+    }
+    
+    static func canShowMyPage(from: UIViewController, user: CredifyUserModel) -> Bool {
+        let tableName = "serviceX"
+        var errorMessage = ""
+        
+        // Phone number
+        if !ValidationUtils.isPhoneValid(countryCode: user.countryCode, phoneNumber: user.phoneNumber) {
+            errorMessage.append(String(format:"FieldIsInvalid".localized(tableName: tableName), "\'Phone number\'"))
+            errorMessage.append(" ")
+        }
+        
+        if !errorMessage.isBlankOrEmpty {
+            UIUtils.alert(
+                from: from,
+                title: "Error".localized(tableName: tableName),
+                errorMessage: errorMessage,
+                actionText: "OK".localized(tableName: tableName)
+            )
+            return false
+        }
+        
+        return true
+    }
+    
+    static func canShowDetailPage(from: UIViewController, user: CredifyUserModel, marketId: String) -> Bool {
+        let tableName = "serviceX"
+        var errorMessage = ""
+        
+        // Market id
+        if marketId.isBlankOrEmpty {
+            errorMessage.append(String(format:"FieldIsRequired".localized(tableName: tableName), "\'Market Id\'"))
+            errorMessage.append(" ")
+        }
+        
+        // Phone number
+        if !ValidationUtils.isPhoneValid(countryCode: user.countryCode, phoneNumber: user.phoneNumber) {
+            errorMessage.append(String(format:"FieldIsInvalid".localized(tableName: tableName), "\'Phone number\'"))
+            errorMessage.append(" ")
+        }
+        
+        if !errorMessage.isBlankOrEmpty {
+            UIUtils.alert(
+                from: from,
+                title: "Error".localized(tableName: tableName),
+                errorMessage: errorMessage,
+                actionText: "OK".localized(tableName: tableName)
+            )
+            return false
+        }
+        
+        return true
+    }
+    
+    static func checkBNPLAvailable(
+        from: UIViewController,
+        offers: [OfferData],
+        providers: [Organization]
+    ) -> Bool {
+        let tableName = "serviceX"
+        
+        let isBNPLAvailable = !offers.isEmpty || !providers.isEmpty
+        if !isBNPLAvailable {
+            print("BNPL is not available for this user. You should call BNPL().getBNPLAvailability function to check it.")
+            UIUtils.alert(
+                from: from,
+                title: "Error".localized(tableName: tableName),
+                errorMessage: "BNPLIsNotAvailable".localized(tableName: tableName),
+                actionText: "OK".localized(tableName: tableName)
+            )
+            return false
+        }
+        
+        return true
+    }
+    
+    static func canStartToRedeemOffer(from: UIViewController, user: CredifyUserModel) -> Bool {
+        let tableName = "serviceX"
+        var errorMessage = ""
+        
+        // Market user id
+        if user.id.isBlankOrEmpty {
+            errorMessage.append(String(format:"FieldIsRequired".localized(tableName: tableName), "\'User Id\'"))
+            errorMessage.append(" ")
+        }
+        
+        // Phone number
+        if !ValidationUtils.isPhoneValid(countryCode: user.countryCode, phoneNumber: user.phoneNumber) {
+            errorMessage.append(String(format:"FieldIsInvalid".localized(tableName: tableName), "\'Phone number\'"))
+            errorMessage.append(" ")
+        }
+        
+        if !errorMessage.isBlankOrEmpty {
+            UIUtils.alert(
+                from: from,
+                title: "Error".localized(tableName: tableName),
+                errorMessage: errorMessage,
+                actionText: "OK".localized(tableName: tableName)
+            )
+            return false
+        }
+        
+        return true
+    }
+}

--- a/Credify/Credify/Utils/WebViewUtils.swift
+++ b/Credify/Credify/Utils/WebViewUtils.swift
@@ -1,0 +1,41 @@
+//
+//  WebViewUtils.swift
+//  
+//
+//  Created by Gioan Le on 27/05/2022.
+//
+
+import Foundation
+
+class WebViewUtils {
+    static func isPendingOrCanceledPage(url: String) -> Bool {
+        return isPendingPage(url: url) || isCanceledPage(url: url)
+    }
+    
+    static func isPendingPage(url: String) -> Bool {
+        return url.starts(with: "\(Constants.WEB_URL)/pending-offer")
+    }
+    
+    static func isCanceledPage(url: String) -> Bool {
+        return url.starts(with: "\(Constants.WEB_URL)/canceled-offer")
+    }
+    
+    static var buildScriptToUpdateAppLanguage: String? {
+        get {
+            let language = AppState.shared.language
+            if language != nil {
+                return "window.appLanguage = '\(language!)';"
+            }
+            
+            return nil
+        }
+    }
+    
+    /// 24002: Passport of redeemed list- Start over link on a pending offer
+    /// https://stackoverflow.com/questions/40452034/disable-zoom-in-wkwebview
+    static let scriptToDisableZoomIn = "var meta = document.createElement('meta');" +
+        "meta.name = 'viewport';" +
+        "meta.content = 'width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no, user-scalable=no';" +
+        "var head = document.getElementsByTagName('head')[0];" +
+        "head.appendChild(meta);"
+}

--- a/Credify/Credify/Utils/WebViewUtils.swift
+++ b/Credify/Credify/Utils/WebViewUtils.swift
@@ -22,9 +22,8 @@ class WebViewUtils {
     
     static var buildScriptToUpdateAppLanguage: String? {
         get {
-            let language = AppState.shared.language
-            if language != nil {
-                return "window.appLanguage = '\(language!)';"
+            if let language = AppState.shared.language {
+                return "window.appLanguage = '\(language.rawValue)';"
             }
             
             return nil

--- a/Credify/Credify/WebView/WebPresenter.swift
+++ b/Credify/Credify/WebView/WebPresenter.swift
@@ -54,18 +54,6 @@ class WebPresenter: WebPresenterProtocol {
     
     private let context: PassportContext
     
-    private var pendingUrl: String {
-        get {
-            return "\(Constants.WEB_URL)/pending-offer"
-        }
-    }
-    
-    private var canceledUrl: String {
-        get {
-            return "\(Constants.WEB_URL)/canceled-offer"
-        }
-    }
-    
     init(context: PassportContext) {
         self.context = context
     }
@@ -263,7 +251,7 @@ class WebPresenter: WebPresenterProtocol {
         switch context {
         case .mypage(_), .serviceInstance(_, _, _):
             // In this case, the back button is visible
-            if url.starts(with: pendingUrl) || url.starts(with: canceledUrl) {
+            if WebViewUtils.isPendingOrCanceledPage(url: url) {
                 return true
             }
             
@@ -295,7 +283,7 @@ class WebPresenter: WebPresenterProtocol {
             }
             
             // In this case, the back button is invisible
-            if url.starts(with: pendingUrl) || url.starts(with: canceledUrl) {
+            if WebViewUtils.isPendingOrCanceledPage(url: url) {
                 return false
             }
             
@@ -317,7 +305,7 @@ class WebPresenter: WebPresenterProtocol {
             } != nil
         case .serviceInstance:
             // In this case, the back button is invisible
-            if url.starts(with: pendingUrl) || url.starts(with: canceledUrl) {
+            if WebViewUtils.isPendingOrCanceledPage(url: url) {
                 return false
             }
             
@@ -371,7 +359,7 @@ class WebPresenter: WebPresenterProtocol {
             
             switch self.context {
             case .mypage(_), .serviceInstance:
-                if url != nil && (url!.starts(with: self.pendingUrl) || url!.starts(with: self.canceledUrl)) {
+                if url != nil && WebViewUtils.isPendingOrCanceledPage(url: url!) {
                     let backList = webView.backForwardList.backList
                     if backList.count > 0 {
                         webView.go(to: backList[0])

--- a/Credify/Credify/WebView/WebViewController.swift
+++ b/Credify/Credify/WebView/WebViewController.swift
@@ -35,23 +35,7 @@ class WebViewController: UIViewController {
         }
         
         customizeNavBar()
-        
-        // 24002: Passport of redeemed list- Start over link on a pending offer
-        // https://stackoverflow.com/questions/40452034/disable-zoom-in-wkwebview
-        let disableZoomInScript: String = "var meta = document.createElement('meta');" +
-            "meta.name = 'viewport';" +
-            "meta.content = 'width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no, user-scalable=no';" +
-            "var head = document.getElementsByTagName('head')[0];" +
-            "head.appendChild(meta);"
-        
-        // Use for localization in the web app
-        var languageScript: String? = nil
-        let language = AppState.shared.language
-        if language != nil {
-            languageScript = "window.appLanguage = '\(language!)';"
-        }
             
-        let userDisableZoomInScript: WKUserScript = WKUserScript(source: disableZoomInScript, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
         let configuration = WKWebViewConfiguration()
         let userController = WKUserContentController()
         
@@ -61,10 +45,22 @@ class WebViewController: UIViewController {
         
         configuration.userContentController = userController
         configuration.allowsInlineMediaPlayback = true // Needed for eKYC camera
-        configuration.userContentController.addUserScript(userDisableZoomInScript)
-        if languageScript != nil {
+        // Disable zoom in
+        configuration.userContentController.addUserScript(
+            WKUserScript(
+                source: WebViewUtils.scriptToDisableZoomIn,
+                injectionTime: .atDocumentEnd,
+                forMainFrameOnly: true
+            )
+        )
+        // Update language
+        if let languageScript = WebViewUtils.buildScriptToUpdateAppLanguage {
             configuration.userContentController.addUserScript(
-                WKUserScript(source: languageScript!, injectionTime: .atDocumentStart, forMainFrameOnly: true)
+                WKUserScript(
+                    source: languageScript,
+                    injectionTime: .atDocumentStart,
+                    forMainFrameOnly: true
+                )
             )
         }
         

--- a/Credify/Credify/serviceX.swift
+++ b/Credify/Credify/serviceX.swift
@@ -40,38 +40,19 @@ public struct serviceX {
             pushClaimTokensTask: @escaping ((String, ((Bool) -> Void)?) -> Void),
             completion: @escaping (() -> Void)
         ) {
-            let tableName = "serviceX"
-            var errorMessage = ""
-            
-            // Phone number
-            let countryCode = user.countryCode.trimmingCharacters(in: .whitespacesAndNewlines)
-            let phoneNumber = user.phoneNumber.trimmingCharacters(in: .whitespacesAndNewlines)
-            if countryCode.isEmpty || phoneNumber.isEmpty || phoneNumber.count < 8 || phoneNumber.count > 12 {
-                errorMessage.append(String(format:"FieldIsInvalid".localized(tableName: tableName), "\'Phone number\'"))
-                errorMessage.append(" ")
-            }
-            
-            // All are valid
-            if errorMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                AppState.shared.pushClaimTokensTask = pushClaimTokensTask
-                AppState.shared.dismissCompletion = completion
-                
-                let context = PassportContext.mypage(user: user)
-                let vc = WebViewController.instantiate(context: context)
-                let navigationController = UINavigationController(rootViewController: vc)
-                navigationController.modalPresentationStyle = .overFullScreen
-                navigationController.interactivePopGestureRecognizer?.isEnabled = false // disable navigation bar swipe back
-                from.present(navigationController, animated: true)
+            if !ValidationUtils.canShowMyPage(from: from, user: user) {
                 return
             }
             
-            // Show error
-            UIUtils.alert(
-                from: from,
-                title: "Error".localized(tableName: tableName),
-                errorMessage: errorMessage,
-                actionText: "OK".localized(tableName: tableName)
-            )
+            AppState.shared.pushClaimTokensTask = pushClaimTokensTask
+            AppState.shared.dismissCompletion = completion
+            
+            let context = PassportContext.mypage(user: user)
+            let vc = WebViewController.instantiate(context: context)
+            let navigationController = UINavigationController(rootViewController: vc)
+            navigationController.modalPresentationStyle = .overFullScreen
+            navigationController.interactivePopGestureRecognizer?.isEnabled = false // disable navigation bar swipe back
+            from.present(navigationController, animated: true)
         }
         
         
@@ -90,42 +71,17 @@ public struct serviceX {
             productTypes: [ProductType],
             completion: @escaping (() -> Void)
         ) {
-            let tableName = "serviceX"
-            var errorMessage = ""
-            
-            // Market id
-            if marketId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                errorMessage.append(String(format:"FieldIsRequired".localized(tableName: tableName), "\'Market Id\'"))
-                errorMessage.append(" ")
-            }
-            
-            // Phone number
-            let countryCode = user.countryCode.trimmingCharacters(in: .whitespacesAndNewlines)
-            let phoneNumber = user.phoneNumber.trimmingCharacters(in: .whitespacesAndNewlines)
-            if countryCode.isEmpty || phoneNumber.isEmpty || phoneNumber.count < 8 || phoneNumber.count > 12 {
-                errorMessage.append(String(format:"FieldIsInvalid".localized(tableName: tableName), "\'Phone number\'"))
-                errorMessage.append(" ")
-            }
-            
-            // All are valid
-            if errorMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                AppState.shared.dismissCompletion = completion
-                let context = PassportContext.serviceInstance(user: user, marketId: marketId, productTypes: productTypes)
-                let vc = WebViewController.instantiate(context: context)
-                let navigationController = UINavigationController(rootViewController: vc)
-                navigationController.modalPresentationStyle = .overFullScreen
-                navigationController.interactivePopGestureRecognizer?.isEnabled = false // disable navigation bar swipe back
-                from.present(navigationController, animated: true)
+            if !ValidationUtils.canShowDetailPage(from: from, user: user, marketId: marketId) {
                 return
             }
             
-            // Show error
-            UIUtils.alert(
-                from: from,
-                title: "Error".localized(tableName: tableName),
-                errorMessage: errorMessage,
-                actionText: "OK".localized(tableName: tableName)
-            )
+            AppState.shared.dismissCompletion = completion
+            let context = PassportContext.serviceInstance(user: user, marketId: marketId, productTypes: productTypes)
+            let vc = WebViewController.instantiate(context: context)
+            let navigationController = UINavigationController(rootViewController: vc)
+            navigationController.modalPresentationStyle = .overFullScreen
+            navigationController.interactivePopGestureRecognizer?.isEnabled = false // disable navigation bar swipe back
+            from.present(navigationController, animated: true)
         }
     }
     
@@ -160,44 +116,19 @@ public struct serviceX {
                                    userProfile: CredifyUserModel,
                                    pushClaimTokensTask: @escaping ((String, ((Bool) -> Void)?) -> Void),
                                    completionHandler: @escaping (RedemptionResult) -> Void) {
-            let tableName = "serviceX"
-            var errorMessage = ""
-            
-            // Market user id
-            if userProfile.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                errorMessage.append(String(format:"FieldIsRequired".localized(tableName: tableName), "\'User Id\'"))
-                errorMessage.append(" ")
-            }
-            
-            // Phone number
-            let countryCode = userProfile.countryCode.trimmingCharacters(in: .whitespacesAndNewlines)
-            let phoneNumber = userProfile.phoneNumber.trimmingCharacters(in: .whitespacesAndNewlines)
-            if countryCode.isEmpty || phoneNumber.isEmpty || phoneNumber.count < 8 || phoneNumber.count > 12 {
-                errorMessage.append(String(format:"FieldIsInvalid".localized(tableName: tableName), "\'Phone number\'"))
-                errorMessage.append(" ")
-            }
-            
-            // All are valid
-            if errorMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                AppState.shared.pushClaimTokensTask = pushClaimTokensTask
-                AppState.shared.redemptionResult = completionHandler
-                
-                let context = PassportContext.offer(offer: offer, user: userProfile)
-                let vc = WebViewController.instantiate(context: context)
-                let navigationController = UINavigationController(rootViewController: vc)
-                navigationController.modalPresentationStyle = .overFullScreen
-                navigationController.interactivePopGestureRecognizer?.isEnabled = false // disable navigation bar swipe back
-                from.present(navigationController, animated: true)
+            if !ValidationUtils.canStartToRedeemOffer(from: from, user: userProfile) {
                 return
             }
             
-            // Show error
-            UIUtils.alert(
-                from: from,
-                title: "Error".localized(tableName: tableName),
-                errorMessage: errorMessage,
-                actionText: "OK".localized(tableName: tableName)
-            )
+            AppState.shared.pushClaimTokensTask = pushClaimTokensTask
+            AppState.shared.redemptionResult = completionHandler
+            
+            let context = PassportContext.offer(offer: offer, user: userProfile)
+            let vc = WebViewController.instantiate(context: context)
+            let navigationController = UINavigationController(rootViewController: vc)
+            navigationController.modalPresentationStyle = .overFullScreen
+            navigationController.interactivePopGestureRecognizer?.isEnabled = false // disable navigation bar swipe back
+            from.present(navigationController, animated: true)
         }
     }
     
@@ -287,67 +218,33 @@ public struct serviceX {
                                    orderId: String,
                                    pushClaimTokensTask: @escaping ((String, ((Bool) -> Void)?) -> Void),
                                    completionHandler: @escaping (_ status: RedemptionResult,_ orderId: String, _ isPaymentCompleted: Bool) -> Void) {
-            let tableName = "serviceX"
             let appState = AppState.shared
-            
             let bnplOfferInfo = appState.bnplOfferInfo
             let offers = bnplOfferInfo?.offers ?? []
             let connectedProviders = bnplOfferInfo?.providers ?? []
             
-            let isBNPLAvailable = !offers.isEmpty || !connectedProviders.isEmpty
-            if !isBNPLAvailable {
-                print("BNPL is not available for this user. You should call BNPL().getBNPLAvailability function to check it.")
-                UIUtils.alert(
-                    from: from,
-                    title: "Error".localized(tableName: tableName),
-                    errorMessage: "BNPLIsNotAvailable".localized(tableName: tableName),
-                    actionText: "OK".localized(tableName: tableName)
-                )
-                return
-            }
-        
-            var errorMessage = ""
-            
-            // Market user id
-            if userProfile.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                errorMessage.append(String(format:"FieldIsRequired".localized(tableName: tableName), "\'User Id\'"))
-                errorMessage.append(" ")
-            }
-            
-            // Phone number
-            let countryCode = userProfile.countryCode.trimmingCharacters(in: .whitespacesAndNewlines)
-            let phoneNumber = userProfile.phoneNumber.trimmingCharacters(in: .whitespacesAndNewlines)
-            if countryCode.isEmpty || phoneNumber.isEmpty || phoneNumber.count < 8 || phoneNumber.count > 12 {
-                errorMessage.append(String(format:"FieldIsInvalid".localized(tableName: tableName), "\'Phone number\'"))
-                errorMessage.append(" ")
-            }
-            
-            // All are valid
-            if errorMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                appState.pushClaimTokensTask = pushClaimTokensTask
-                appState.bnplRedemptionResult = completionHandler
-                
-                let context = PassportContext.bnpl(
-                    offers: offers,
-                    user: userProfile,
-                    orderId: orderId,
-                    completedBnplProviders: connectedProviders
-                )
-                let vc = WebViewController.instantiate(context: context)
-                let navigationController = UINavigationController(rootViewController: vc)
-                navigationController.modalPresentationStyle = .overFullScreen
-                navigationController.interactivePopGestureRecognizer?.isEnabled = false // disable navigation bar swipe back
-                from.present(navigationController, animated: true)
+            if !ValidationUtils.checkBNPLAvailable(from: from, offers:offers, providers: connectedProviders) {
                 return
             }
             
-            // Show error
-            UIUtils.alert(
-                from: from,
-                title: "Error".localized(tableName: tableName),
-                errorMessage: errorMessage,
-                actionText: "OK".localized(tableName: tableName)
+            if !ValidationUtils.canStartToRedeemOffer(from: from, user: userProfile) {
+                return
+            }
+            
+            appState.pushClaimTokensTask = pushClaimTokensTask
+            appState.bnplRedemptionResult = completionHandler
+            
+            let context = PassportContext.bnpl(
+                offers: offers,
+                user: userProfile,
+                orderId: orderId,
+                completedBnplProviders: connectedProviders
             )
+            let vc = WebViewController.instantiate(context: context)
+            let navigationController = UINavigationController(rootViewController: vc)
+            navigationController.modalPresentationStyle = .overFullScreen
+            navigationController.interactivePopGestureRecognizer?.isEnabled = false // disable navigation bar swipe back
+            from.present(navigationController, animated: true)
         }
     }
 }

--- a/Credify/Credify/serviceX.swift
+++ b/Credify/Credify/serviceX.swift
@@ -17,7 +17,7 @@ public struct serviceX {
 //        let userAgent = "servicex/ios/\(sdkVersion)"
     }
     
-    public static func setLanguage(_ language: String) {
+    public static func setLanguage(_ language: Language) {
         AppState.shared.language = language
     }
     
@@ -40,7 +40,7 @@ public struct serviceX {
             pushClaimTokensTask: @escaping ((String, ((Bool) -> Void)?) -> Void),
             completion: @escaping (() -> Void)
         ) {
-            if !ValidationUtils.canShowMyPage(from: from, user: user) {
+            if !ValidationUtils.showErrorIfShowMyPageFails(from: from, user: user) {
                 return
             }
             
@@ -71,7 +71,7 @@ public struct serviceX {
             productTypes: [ProductType],
             completion: @escaping (() -> Void)
         ) {
-            if !ValidationUtils.canShowDetailPage(from: from, user: user, marketId: marketId) {
+            if !ValidationUtils.showErrorIfShowDetailPageFails(from: from, user: user, marketId: marketId) {
                 return
             }
             
@@ -116,7 +116,7 @@ public struct serviceX {
                                    userProfile: CredifyUserModel,
                                    pushClaimTokensTask: @escaping ((String, ((Bool) -> Void)?) -> Void),
                                    completionHandler: @escaping (RedemptionResult) -> Void) {
-            if !ValidationUtils.canStartToRedeemOffer(from: from, user: userProfile) {
+            if !ValidationUtils.showErrorIfOfferCannotStart(from: from, user: userProfile) {
                 return
             }
             
@@ -223,11 +223,11 @@ public struct serviceX {
             let offers = bnplOfferInfo?.offers ?? []
             let connectedProviders = bnplOfferInfo?.providers ?? []
             
-            if !ValidationUtils.checkBNPLAvailable(from: from, offers:offers, providers: connectedProviders) {
+            if !ValidationUtils.showErrorIfBNPLUnavailable(from: from, offers:offers, providers: connectedProviders) {
                 return
             }
             
-            if !ValidationUtils.canStartToRedeemOffer(from: from, user: userProfile) {
+            if !ValidationUtils.showErrorIfOfferCannotStart(from: from, user: userProfile) {
                 return
             }
             

--- a/ExampleApp/ExampleApp/ViewController.swift
+++ b/ExampleApp/ExampleApp/ViewController.swift
@@ -32,9 +32,8 @@ class ViewController: UIViewController {
         let config = serviceXConfig(apiKey: API_KEY, env: .dev, appName: APP_NAME)
         serviceX.configure(config)
         
-        let language = GlobalSubjects.language
-        if language != nil {
-            serviceX.setLanguage(language!)
+        if let language = GlobalSubjects.language {
+            serviceX.setLanguage(language)
         }
         
         user = CredifyUserModel(id: "123", firstName: "Sh", lastName: "Test", email: "vu.nguyen@gmail.com", credifyId: nil, countryCode: "+84", phoneNumber: "381239812")

--- a/ExampleApp/ExampleApp/ViewController.swift
+++ b/ExampleApp/ExampleApp/ViewController.swift
@@ -32,6 +32,11 @@ class ViewController: UIViewController {
         let config = serviceXConfig(apiKey: API_KEY, env: .dev, appName: APP_NAME)
         serviceX.configure(config)
         
+        let language = GlobalSubjects.language
+        if language != nil {
+            serviceX.setLanguage(language!)
+        }
+        
         user = CredifyUserModel(id: "123", firstName: "Sh", lastName: "Test", email: "vu.nguyen@gmail.com", credifyId: nil, countryCode: "+84", phoneNumber: "381239812")
         
         loadOffers()


### PR DESCRIPTION
## Description
- Added the `setLanguage` method to the SDK.
- Updated the `showPassport` function

## Motivation & Context
Ticket: https://app.shortcut.com/credify/story/24002/ios-passport-of-redeemed-list-start-over-link-on-a-pending-offer

## How has this been tested?
Using iOS demo app -> select languages -> do the BNPL, Normal offer, show passport or show service instance features.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.