### PR TITLE
See 2 loading indicators at the same time [24517]

### DIFF
--- a/Credify/Credify/WebView/WebPresenter.swift
+++ b/Credify/Credify/WebView/WebPresenter.swift
@@ -39,6 +39,7 @@ enum PassportContext {
 protocol WebPresenterProtocol {
     var receiveHandlers: [ReceiveMessageHandler] { get }
     func shouldClose(messageName: String) -> Bool
+    func shouldDismissLoading(messageName: String) -> Bool
     func handleMessage(_: WKWebView, name: String, body: [String: Any]?)
     func hanldeCompletionHandler()
     func isBackButtonVisible(urlObj: URL?) -> Bool
@@ -78,6 +79,14 @@ class WebPresenter: WebPresenterProtocol {
             return false
         }
         return type == .actionClose || type == .bnplPaymentComplete
+    }
+    
+    /// 24517: See 2 loading indicators at the same time
+    func shouldDismissLoading(messageName: String) -> Bool {
+        guard let type = ReceiveMessageHandler(rawValue: messageName) else {
+            return false
+        }
+        return type == .loginLoadCompleted || type == .initialLoadCompleted
     }
     
     func handleMessage(_ webView: WKWebView, name: String, body: [String: Any]?) {

--- a/Credify/Credify/WebView/WebViewController.swift
+++ b/Credify/Credify/WebView/WebViewController.swift
@@ -298,6 +298,11 @@ extension WebViewController: WKScriptMessageHandler{
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         let body = message.body as? [String: Any]
         
+        // 24517: See 2 loading indicators at the same time
+        if presenter.shouldDismissLoading(messageName: message.name) {
+            LoadingView.stop()
+        }
+        
         if presenter.shouldClose(messageName: message.name) {
             dismiss(animated: true) {
                 self.presenter.handleMessage(self.webView, name: message.name, body: body)


### PR DESCRIPTION
## Description
- I fixed the bug in [this ticket](https://app.shortcut.com/credify/story/24517/ios-see-2-loading-indicators-at-the-same-time)

## Motivation & Context
Ticket: https://app.shortcut.com/credify/story/24517/ios-see-2-loading-indicators-at-the-same-time

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.