### PR TITLE
BNPL Send total amount to passport web app [25581]

### DIFF
--- a/Credify/Credify/Objects/CommonModel.swift
+++ b/Credify/Credify/Objects/CommonModel.swift
@@ -238,10 +238,12 @@ public class JSONCodingKey: CodingKey {
     }
 }
 
-internal class OrderInfo : Codable {
+public class OrderInfo : Codable {
     let orderId: String
+    let orderAmount: Double
     
-    init(orderId: String) {
+    public init(orderId: String, orderAmount: Double) {
         self.orderId = orderId
+        self.orderAmount = orderAmount
     }
 }

--- a/Credify/Credify/Objects/CommonModel.swift
+++ b/Credify/Credify/Objects/CommonModel.swift
@@ -240,9 +240,9 @@ public class JSONCodingKey: CodingKey {
 
 public class OrderInfo : Codable {
     let orderId: String
-    let orderAmount: Double
+    let orderAmount: FiatCurrency
     
-    public init(orderId: String, orderAmount: Double) {
+    public init(orderId: String, orderAmount: FiatCurrency) {
         self.orderId = orderId
         self.orderAmount = orderAmount
     }

--- a/Credify/Credify/Objects/Entities.swift
+++ b/Credify/Credify/Objects/Entities.swift
@@ -252,6 +252,11 @@ public struct InsurancePackageModel: Codable {
 public struct FiatCurrency: Codable {
     public let value: String
     public let currency: String
+    
+    public init(value: String, currency: String) {
+        self.value = value
+        self.currency = currency
+    }
 }
 
 public struct Scope: Codable {

--- a/Credify/Credify/Objects/Entities.swift
+++ b/Credify/Credify/Objects/Entities.swift
@@ -202,11 +202,37 @@ public struct ProductModel: Codable {
     
     public struct ProductDetail: Codable {
         internal let packages: [InsurancePackageModel]?
+        internal let availableTerms: [AvailableTerms]?
         
         public var insurancePackages: [InsurancePackageModel] {
             return packages ?? [InsurancePackageModel]()
         }
+        
+        public var terms: [AvailableTerms] {
+            return availableTerms ?? [AvailableTerms]()
+        }
+        
+        private enum CodingKeys: String, CodingKey {
+            case packages
+            case availableTerms = "available_terms"
+        }
     }
+}
+
+public struct AvailableTerms : Codable {
+    public let duration: AvailableTermsDuration?
+    public let fee: AvailableTermsFee?
+    public let interest: Float?
+}
+
+
+public struct AvailableTermsDuration : Codable {
+    public let value: Int64
+    public let unit: String
+}
+
+public struct AvailableTermsFee : Codable {
+    public let type: Int
 }
 
 public struct InsurancePackageModel: Codable {

--- a/Credify/Credify/WebView/WebViewController.swift
+++ b/Credify/Credify/WebView/WebViewController.swift
@@ -220,6 +220,8 @@ class WebViewController: UIViewController {
             // Disable scroll
             webView.scrollView.bounces = false
             webView.scrollView.isScrollEnabled = false
+            // Disable preview to avoid white page
+            webView.allowsLinkPreview = false
             
             webView.load(URLRequest(url: url))
         }

--- a/Credify/Credify/serviceX.swift
+++ b/Credify/Credify/serviceX.swift
@@ -215,7 +215,7 @@ public struct serviceX {
         ///   - completionHandler: Completion handler. You can get notified about the result of the BNPL flow.
         public func presentModally(from: UIViewController,
                                    userProfile: CredifyUserModel,
-                                   orderId: String,
+                                   orderInfo: OrderInfo,
                                    pushClaimTokensTask: @escaping ((String, ((Bool) -> Void)?) -> Void),
                                    completionHandler: @escaping (_ status: RedemptionResult,_ orderId: String, _ isPaymentCompleted: Bool) -> Void) {
             let appState = AppState.shared
@@ -237,7 +237,7 @@ public struct serviceX {
             let context = PassportContext.bnpl(
                 offers: offers,
                 user: userProfile,
-                orderId: orderId,
+                orderInfo: orderInfo,
                 completedBnplProviders: connectedProviders
             )
             let vc = WebViewController.instantiate(context: context)

--- a/README.md
+++ b/README.md
@@ -148,14 +148,14 @@ class SampleViewController: UIViewController {
     }
     
     /// This will check whether BNPL is available or not
-    /// You need to create "orderId" on your side.
-    func getBNPLAvailability(orderId: String) {
+    /// You need to create "orderInfo" on your side.
+    func getBNPLAvailability(orderInfo: OrderInfo) {
         bnpl.getBNPLAvailability(user: self.user) { result in
             switch result {
             case .success((let isAvailable, let credifyId)):
                 if isAvailable {
                     // This will start BNPL flow
-                    self.startBNPL(orderId: orderId)
+                    self.startBNPL(orderInfo: OrderInfo)
                     return
                 }
                 
@@ -168,8 +168,8 @@ class SampleViewController: UIViewController {
     }
 
     /// This starts Credify SDK
-    /// You need to create "orderId" on your side.
-    func startBNPL(orderId: String) {
+    /// You need to create "orderInfo" on your side.
+    func startBNPL(orderInfo: OrderInfo) {
         let task: ((String, ((Bool) -> Void)?) -> Void) = { credifyId, result in
             // Using Alamofire
             AF.request(API_PUSH_CLAIMS,
@@ -188,7 +188,7 @@ class SampleViewController: UIViewController {
         bnpl.presentModally(
                 from: self,
                 userProfile: self.user,
-                orderId: orderId,
+                orderInfo: orderInfo,
                 pushClaimTokensTask: task
         ) { [weak self] status, orderId, isPaymentCompleted in
             self?.dismiss(animated: false) {


### PR DESCRIPTION
## Description
- Passport `OrderInfo`(orderId, orderAmount) to the passport app.
- Added `availableTerms` to `ProductDetail` object.

## Motivation & Context
Ticket: https://app.shortcut.com/credify/story/24892/passport-web-sdk-map-bnpl-product-into-passport-app

## How has this been tested?
Test BNPL and it should show about `interest rate` info

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.