### PR TITLE
HouseCare - Add bannerUrl to the Campaign object [25994]

### DIFF
--- a/Credify.podspec
+++ b/Credify.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "Credify"
-  spec.version      = "0.5.0"
+  spec.version      = "0.5.1"
   spec.summary      = "serviceX SDK is for marketplaces to integrate Credify serviceX."
   spec.description  = "This is an SDK for Credify serviceX distributed for iOS platform."
   spec.homepage     = "https://github.com/credify-pte-ltd/credify-ios-sdk"

--- a/Credify/Credify/Objects/Entities.swift
+++ b/Credify/Credify/Objects/Entities.swift
@@ -83,6 +83,8 @@ public struct OfferCampaign: Codable {
     public let extraSteps: Bool?
     public let levels: [String]?
     public let thumbnailUrl: String?
+    // 25994: HouseCare - Add bannerUrl to the Campaign object
+    public let bannerUrl: String?
     public let verificationScopes: [String]?
     public let useReferral: Bool
     public var product: ProductModel?
@@ -100,6 +102,7 @@ public struct OfferCampaign: Codable {
                 verificationScopes: [String]?,
                 levels: [String]?,
                 thumbnailUrl: String?,
+                bannerUrl: String?,
                 useReferral: Bool,
                 product: ProductModel?,
                 requiredStandardScopes: [String],
@@ -116,6 +119,7 @@ public struct OfferCampaign: Codable {
         self.levels = levels
         self.verificationScopes = verificationScopes
         self.thumbnailUrl = thumbnailUrl
+        self.bannerUrl = bannerUrl
         self.useReferral = useReferral
         self.product = product
         self.requiredStandardScopes = requiredStandardScopes
@@ -133,6 +137,7 @@ public struct OfferCampaign: Codable {
         case extraSteps = "extra_steps"
         case levels
         case thumbnailUrl = "thumbnail_url"
+        case bannerUrl = "banner_url"
         case verificationScopes = "verified_scopes"
         case useReferral = "use_referral"
         case product


### PR DESCRIPTION
## Description
- Added `bannerUrl` to the Campaign object. It's reported by HouseCare

## Motivation & Context
Ticket: https://app.shortcut.com/credify/story/25994/ios-housecare-add-bannerurl-to-the-campaign-object

## How has this been tested?
Can see `bannerUrl` in the Campaign object.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.