### PR TITLE
Update iOS SDK to help user can close the landing page [27632]

### DIFF
--- a/Credify.xcodeproj/project.pbxproj
+++ b/Credify.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		2517EC9127E5AFC80025E396 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 2517EC9027E5AFC80025E396 /* README.md */; };
 		2FE4974A25B84DE65ABFE2FE /* Pods_Credify_CredifyTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EBE6BA2E897790A987AA1126 /* Pods_Credify_CredifyTests.framework */; };
 		E0C17D0D9B8627E0F7DBC0A5 /* Pods_Credify.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C7A244039A269E07690C793C /* Pods_Credify.framework */; };
+		F80B1ADB28891723006FB92F /* SimpleWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F80B1ADA28891723006FB92F /* SimpleWebViewController.swift */; };
 		F83B400427E89DF200A01A2E /* PostMessageUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = F83B400327E89DF200A01A2E /* PostMessageUtils.swift */; };
 		F83B400627E89E7300A01A2E /* PostMessageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F83B400527E89E7300A01A2E /* PostMessageModel.swift */; };
 		F84828B227EADC9200ED1E12 /* serviceX.strings in Resources */ = {isa = PBXBuildFile; fileRef = F84828B027EADC9200ED1E12 /* serviceX.strings */; };
@@ -119,6 +120,7 @@
 		BFF408E83C2BFE352C258BE7 /* Pods-Credify.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Credify.release.xcconfig"; path = "Target Support Files/Pods-Credify/Pods-Credify.release.xcconfig"; sourceTree = "<group>"; };
 		C7A244039A269E07690C793C /* Pods_Credify.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Credify.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EBE6BA2E897790A987AA1126 /* Pods_Credify_CredifyTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Credify_CredifyTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F80B1ADA28891723006FB92F /* SimpleWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleWebViewController.swift; sourceTree = "<group>"; };
 		F83B400327E89DF200A01A2E /* PostMessageUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostMessageUtils.swift; sourceTree = "<group>"; };
 		F83B400527E89E7300A01A2E /* PostMessageModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostMessageModel.swift; sourceTree = "<group>"; };
 		F84828B127EADC9200ED1E12 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = Credify/en.lproj/serviceX.strings; sourceTree = "<group>"; };
@@ -249,6 +251,7 @@
 		2517EC4327E5A4520025E396 /* WebView */ = {
 			isa = PBXGroup;
 			children = (
+				F80B1AD928891703006FB92F /* SimpleWebView */,
 				2517EC4427E5A4520025E396 /* WebPresenter.swift */,
 				F8E9FFA528068C2400F25B59 /* CommonModel.swift */,
 				2517EC4527E5A4520025E396 /* WebViewController.swift */,
@@ -337,6 +340,14 @@
 				EBE6BA2E897790A987AA1126 /* Pods_Credify_CredifyTests.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		F80B1AD928891703006FB92F /* SimpleWebView */ = {
+			isa = PBXGroup;
+			children = (
+				F80B1ADA28891723006FB92F /* SimpleWebViewController.swift */,
+			);
+			path = SimpleWebView;
 			sourceTree = "<group>";
 		};
 		F83B400227E89DF200A01A2E /* Utils */ = {
@@ -609,6 +620,7 @@
 				2517EC3B27E5A4360025E396 /* Dictionary+Extension.swift in Sources */,
 				F87CBCD4284488740032B196 /* LoadingView.swift in Sources */,
 				2517EC5E27E5A4520025E396 /* serviceXConfig.swift in Sources */,
+				F80B1ADB28891723006FB92F /* SimpleWebViewController.swift in Sources */,
 				2517EC3427E5A4360025E396 /* UIFont+Extension.swift in Sources */,
 				2517EC2227E5A3B40025E396 /* Constants.swift in Sources */,
 				2517EC3727E5A4360025E396 /* UIViewController+Extension.swift in Sources */,

--- a/Credify/Credify/Objects/PostMessageModel.swift
+++ b/Credify/Credify/Objects/PostMessageModel.swift
@@ -31,6 +31,7 @@ internal enum ReceiveMessageHandler: String {
     case sendPathsForShowingCloseButton
     case loginLoadCompleted
     case promotionOfferLoadCompleted
+    case openRedirectUrl
 }
 
 internal class StartBnplMessage: Codable {

--- a/Credify/Credify/WebView/SimpleWebView/SimpleWebViewController.swift
+++ b/Credify/Credify/WebView/SimpleWebView/SimpleWebViewController.swift
@@ -1,0 +1,264 @@
+//
+//  SimpleWebViewController.swift
+//  Credify
+//
+//  Created by Gioan Le on 21/07/2022.
+//
+
+import UIKit
+import WebKit
+import SafariServices
+
+/// I create this class to show simple web page only. Don't effect with our logic 
+class SimpleWebViewController: UIViewController {
+    private var webView: WKWebView!
+    
+    private var url: URL!
+    
+    private var originalWebViewFrame: CGRect? = nil
+    
+    private var statusBarHeight: CGFloat {
+        get {
+            let window = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
+            var statusBarHeight: CGFloat = 0
+            if #available(iOS 13.0, *) {
+                statusBarHeight = window?.windowScene?.statusBarManager?.statusBarFrame.height ?? 0
+            }
+            return statusBarHeight
+        }
+    }
+    
+    private var webViewHeight: CGFloat {
+        get {
+            // Have nav bar
+            // let navAndStatusBarHeight = (navigationController?.navigationBar.frame.height ?? 0) + statusBarHeight
+            // Have not nav bar
+            let navAndStatusBarHeight = statusBarHeight
+            
+            let height: CGFloat
+            
+            if #available(iOS 11.0, *) {
+                height = view.safeAreaLayoutGuide.layoutFrame.height - navAndStatusBarHeight
+            } else {
+                height = view.frame.height - navAndStatusBarHeight
+            }
+            
+            return height
+        }
+    }
+    
+    private var paddingBottom: CGFloat {
+        get {
+            var padding: CGFloat = 0.0
+            
+            if #available(iOS 11.0, *) {
+                padding = 8.0
+            }
+            
+            return padding
+        }
+    }
+    
+    static func instantiate(url: URL) -> SimpleWebViewController {
+        let vc = SimpleWebViewController()
+        vc.url = url
+        return vc
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        if #available(iOS 13.0, *) {
+            overrideUserInterfaceStyle = .light
+        }
+        
+        customizeNavBar()
+            
+        setupWebView()
+        
+        LoadingView.start(container: view)
+    }
+    
+    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+        if keyPath == "title"  {
+            title = webView.title ?? ""
+        }
+        
+        if keyPath == "estimatedProgress" {
+            print(Float(webView.estimatedProgress))
+        }
+    }
+    
+    
+    // MARK: - Private functions
+    
+    private func createWebViewConfiguration() -> WKWebViewConfiguration {
+        let configuration = WKWebViewConfiguration()
+        
+        // Needed for eKYC camera
+        configuration.allowsInlineMediaPlayback = true
+        
+        // Disable zoom in
+        configuration.userContentController.addUserScript(
+            WKUserScript(
+                source: WebViewUtils.scriptToDisableZoomIn,
+                injectionTime: .atDocumentEnd,
+                forMainFrameOnly: true
+            )
+        )
+        
+        // Update language
+        if let languageScript = WebViewUtils.buildScriptToUpdateAppLanguage {
+            configuration.userContentController.addUserScript(
+                WKUserScript(
+                    source: languageScript,
+                    injectionTime: .atDocumentStart,
+                    forMainFrameOnly: true
+                )
+            )
+        }
+        
+        return configuration
+    }
+    
+    private func setupWebView() {
+        let configuration = createWebViewConfiguration()
+        
+        // 21840: UI issue - Long text and cut off button
+        let webViewFrame: CGRect
+        if #available(iOS 11.0, *) {
+            let safeAreaFrame = view.safeAreaLayoutGuide.layoutFrame
+            webViewFrame = CGRect(origin: CGPoint(x: 0, y: 0), size: safeAreaFrame.size)
+        } else {
+            let viewFrame = view.frame
+            webViewFrame = CGRect(origin: CGPoint(x: 0, y: 0), size: viewFrame.size)
+        }
+        
+        webView = WKWebView(frame: webViewFrame,configuration: configuration)
+        view.addSubview(webView)
+        
+        self.originalWebViewFrame = webView.frame
+        
+        // 23274: Investigate caching issue on webview
+        // Clear website data first for testing some bugs to make sure
+        // that the bugs happen due to caching issue
+        // If it fixed these bugs then we need to think about the improvement for caching.
+        guard let webView = self.webView else { return }
+        guard let url = self.url else { return }
+
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        webView.uiDelegate = self
+        webView.navigationDelegate = self
+
+        webView.allowsBackForwardNavigationGestures = true
+        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.title), options: .new, context: nil)
+        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress), options: .new, context: nil)
+        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.url), options: .new, context: nil)
+        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.canGoBack), options: .new, context: nil)
+        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.canGoForward), options: .new, context: nil)
+        webView.customUserAgent = AppState.shared.config?.userAgent
+        // Disable preview to avoid white page
+        webView.allowsLinkPreview = false
+        
+        webView.load(URLRequest(url: url))
+        
+        // 26031: Housecare ios - SDK - styling issue
+        // Position the WebView
+        // Leading and Trailing
+        NSLayoutConstraint.activate([
+            webView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+        
+        // Top and Bottom
+        if #available(iOS 11, *) {
+            let guide = view.safeAreaLayoutGuide
+            NSLayoutConstraint.activate([
+                webView.topAnchor.constraint(equalToSystemSpacingBelow: guide.topAnchor, multiplier: 0.0),
+                guide.bottomAnchor.constraint(equalToSystemSpacingBelow: webView.bottomAnchor, multiplier: 0.0)
+            ])
+        } else {
+            NSLayoutConstraint.activate([
+                webView.topAnchor.constraint(equalTo: topLayoutGuide.bottomAnchor, constant: 0),
+                bottomLayoutGuide.topAnchor.constraint(equalTo: webView.bottomAnchor, constant: 0)
+            ])
+        }
+    }
+    
+    private func customizeNavBar() {
+        guard let navBar = navigationController?.navigationBar else {
+            return
+        }
+        
+        navBar.backgroundColor = UIColor.white
+        
+        navBar.titleTextAttributes = [
+            .foregroundColor: UIColor.black,
+        ]
+        
+        navBar.tintColor = UIColor.black
+        if #available(iOS 13.0, *) {
+            navigationItem.leftBarButtonItem = UIBarButtonItem(
+                image: UIImage(named: "ic_back", in: Bundle.serviceX, with: nil),
+                style: .plain,
+                target: self,
+                action: #selector(goBack)
+            )
+        } else {
+            navigationItem.leftBarButtonItem = UIBarButtonItem(
+                image: UIImage(named: "ic_back", in: Bundle.serviceX, compatibleWith: nil),
+                style: .plain,
+                target: self,
+                action: #selector(goBack)
+            )
+        }
+    }
+    
+    @objc private func goBack() {
+        if webView.canGoBack {
+            webView.goBack()
+            return
+        }
+        
+        close()
+    }
+    
+    @objc private func close() {
+        dismiss(animated: true){}
+    }
+}
+
+extension SimpleWebViewController: WKUIDelegate {
+    func webView(_ webView: WKWebView, runJavaScriptAlertPanelWithMessage message:
+                 String, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping () ->
+                 Void) {
+        let alertController = UIAlertController(title: message, message: nil, preferredStyle:
+                                                        .alert)
+        
+        alertController.addAction(UIAlertAction(title: "OK", style: .cancel) {_ in
+            completionHandler()})
+        
+        present(alertController, animated: true)
+    }
+    
+    func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
+        guard let url = navigationAction.request.url else {
+            return nil
+        }
+        guard let targetFrame = navigationAction.targetFrame, targetFrame.isMainFrame else {
+            let vc = SFSafariViewController(url: url)
+            let nvc = UINavigationController(rootViewController: vc)
+            nvc.modalPresentationStyle = .overFullScreen
+            present(nvc, animated: true)
+            
+            return nil
+        }
+        return nil
+    }
+}
+
+extension SimpleWebViewController: WKNavigationDelegate {
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        LoadingView.stop()
+    }
+}

--- a/Credify/Credify/WebView/WebViewController.swift
+++ b/Credify/Credify/WebView/WebViewController.swift
@@ -500,9 +500,19 @@ extension WebViewController: WKScriptMessageHandler{
             dismiss(animated: true) {
                 self.presenter.handleMessage(self.webView, name: message.name, body: body)
             }
-        } else {
-            presenter.handleMessage(webView, name: message.name, body: body)
+            return
         }
+        
+        if presenter.isOpenRedirectUrlMessageForOffer(name: message.name) {
+            if let urlStr = presenter.extractRedirectUrlForOffer(body: body), let url = URL(string: urlStr) {
+                let vc = SimpleWebViewController.instantiate(url: url)
+                let navigationController = UIUtils.createUINavigationController(vc: vc)
+                present(navigationController, animated: true)
+                return
+            }
+        }
+        
+        presenter.handleMessage(webView, name: message.name, body: body)
     }
 }
 

--- a/Credify/Credify/WebView/WebViewController.swift
+++ b/Credify/Credify/WebView/WebViewController.swift
@@ -9,54 +9,18 @@ import UIKit
 import WebKit
 import SafariServices
 
-class WebViewController: UIViewController {
-    private var maskBackgroud: UIView!
-    private var webView: WKWebView!
-    
-    private var url: URL!
+class WebViewController: SimpleWebViewController {
     private var presenter: WebPresenterProtocol!
     
-    private var originalWebViewFrame: CGRect? = nil
-    
-    private var statusBarHeight: CGFloat {
+    override var shouldShowNavBar: Bool {
         get {
-            let window = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
-            var statusBarHeight: CGFloat = 0
-            if #available(iOS 13.0, *) {
-                statusBarHeight = window?.windowScene?.statusBarManager?.statusBarFrame.height ?? 0
-            }
-            return statusBarHeight
+            return false
         }
     }
     
-    private var webViewHeight: CGFloat {
+    override var shouldClearCache: Bool {
         get {
-            // Have nav bar
-            // let navAndStatusBarHeight = (navigationController?.navigationBar.frame.height ?? 0) + statusBarHeight
-            // Have not nav bar
-            let navAndStatusBarHeight = statusBarHeight
-            
-            let height: CGFloat
-            
-            if #available(iOS 11.0, *) {
-                height = view.safeAreaLayoutGuide.layoutFrame.height - navAndStatusBarHeight
-            } else {
-                height = view.frame.height - navAndStatusBarHeight
-            }
-            
-            return height
-        }
-    }
-    
-    private var paddingBottom: CGFloat {
-        get {
-            var padding: CGFloat = 0.0
-            
-            if #available(iOS 11.0, *) {
-                padding = 8.0
-            }
-            
-            return padding
+            return true
         }
     }
     
@@ -70,10 +34,6 @@ class WebViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        if #available(iOS 13.0, *) {
-            overrideUserInterfaceStyle = .light
-        }
-        
         let theme = AppState.shared.config?.theme
         let themeColor = theme?.color
         let isBackgroundTransparent = presenter.shouldUseTransparentBackground(url: self.url.absoluteString)
@@ -83,24 +43,10 @@ class WebViewController: UIViewController {
         // 23462: Med247 app - Passport's background does not fit with height of Med247 app
         updateBackground(themeColor: themeColor, isTransparentBackground: isBackgroundTransparent)
         
-        customizeNavBar(themeColor: themeColor)
-            
-        setupWebView(themeColor: themeColor)
-        
         updateWebViewBackground(themeColor: themeColor, isTransparentBackground: isBackgroundTransparent)
-        
-        LoadingView.start(container: view)
     }
     
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
-        if keyPath == "title"  {
-            title = webView.title ?? ""
-        }
-        
-        if keyPath == "estimatedProgress" {
-            print(Float(webView.estimatedProgress))
-        }
-        
         // Scroll the WKWebView once the page is changed
         if keyPath == #keyPath(WKWebView.url) {
             webView.scrollView.setContentOffset(CGPoint.zero, animated: true)
@@ -112,6 +58,33 @@ class WebViewController: UIViewController {
             updateBackground(themeColor: themeColor, isTransparentBackground: isBackgroundTransparent)
             updateWebViewBackground(themeColor: themeColor, isTransparentBackground: isBackgroundTransparent)
         }
+    }
+    
+    override func createWebView() -> WKWebView {
+        let userController = createWebViewUserContentController()
+        let configuration = createWebViewConfiguration(userController: userController)
+        
+        let webView = WKWebView(frame: webViewFrame, configuration: configuration)
+        
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        webView.uiDelegate = self
+        webView.navigationDelegate = self
+        webView.scrollView.delegate = self
+
+        webView.allowsBackForwardNavigationGestures = true
+        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.title), options: .new, context: nil)
+        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress), options: .new, context: nil)
+        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.url), options: .new, context: nil)
+        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.canGoBack), options: .new, context: nil)
+        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.canGoForward), options: .new, context: nil)
+        webView.customUserAgent = AppState.shared.config?.userAgent
+        // Disable scroll
+        webView.scrollView.bounces = false
+        webView.scrollView.isScrollEnabled = false
+        // Disable preview to avoid white page
+        webView.allowsLinkPreview = false
+        
+        return webView
     }
     
     
@@ -156,80 +129,6 @@ class WebViewController: UIViewController {
         }
         
         return userController
-    }
-    
-    private func setupWebView(themeColor: ThemeColor?) {
-        let userController = createWebViewUserContentController()
-        let configuration = createWebViewConfiguration(userController: userController)
-        
-        // 21840: UI issue - Long text and cut off button
-        let webViewFrame: CGRect
-        if #available(iOS 11.0, *) {
-            let safeAreaFrame = view.safeAreaLayoutGuide.layoutFrame
-            webViewFrame = CGRect(origin: CGPoint(x: 0, y: 0), size: safeAreaFrame.size)
-        } else {
-            let viewFrame = view.frame
-            webViewFrame = CGRect(origin: CGPoint(x: 0, y: 0), size: viewFrame.size)
-        }
-        
-        webView = WKWebView(frame: webViewFrame,configuration: configuration)
-        view.addSubview(webView)
-        
-        self.originalWebViewFrame = webView.frame
-        
-        // 23274: Investigate caching issue on webview
-        // Clear website data first for testing some bugs to make sure
-        // that the bugs happen due to caching issue
-        // If it fixed these bugs then we need to think about the improvement for caching.
-        WKWebsiteDataStore.default().removeData(
-            ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(),
-            modifiedSince: Date(timeIntervalSince1970: 0)
-        ) {
-            guard let webView = self.webView else { return }
-            guard let url = self.url else { return }
-
-            webView.translatesAutoresizingMaskIntoConstraints = false
-            webView.uiDelegate = self
-            webView.navigationDelegate = self
-            webView.scrollView.delegate = self
-
-            webView.allowsBackForwardNavigationGestures = true
-            webView.addObserver(self, forKeyPath: #keyPath(WKWebView.title), options: .new, context: nil)
-            webView.addObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress), options: .new, context: nil)
-            webView.addObserver(self, forKeyPath: #keyPath(WKWebView.url), options: .new, context: nil)
-            webView.addObserver(self, forKeyPath: #keyPath(WKWebView.canGoBack), options: .new, context: nil)
-            webView.addObserver(self, forKeyPath: #keyPath(WKWebView.canGoForward), options: .new, context: nil)
-            webView.customUserAgent = AppState.shared.config?.userAgent
-            // Disable scroll
-            webView.scrollView.bounces = false
-            webView.scrollView.isScrollEnabled = false
-            // Disable preview to avoid white page
-            webView.allowsLinkPreview = false
-            
-            webView.load(URLRequest(url: url))
-        }
-        
-        // 26031: Housecare ios - SDK - styling issue
-        // Position the WebView
-        // Leading and Trailing
-        NSLayoutConstraint.activate([
-            webView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            webView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
-        ])
-        
-        // Top and Bottom
-        if #available(iOS 11, *) {
-            let guide = view.safeAreaLayoutGuide
-            NSLayoutConstraint.activate([
-                webView.topAnchor.constraint(equalToSystemSpacingBelow: guide.topAnchor, multiplier: 0.0),
-                guide.bottomAnchor.constraint(equalToSystemSpacingBelow: webView.bottomAnchor, multiplier: 0.0)
-            ])
-        } else {
-            NSLayoutConstraint.activate([
-                webView.topAnchor.constraint(equalTo: topLayoutGuide.bottomAnchor, constant: 0),
-                bottomLayoutGuide.topAnchor.constraint(equalTo: webView.bottomAnchor, constant: 0)
-            ])
-        }
     }
     
     private func updateWebViewBackground(themeColor: ThemeColor?, isTransparentBackground: Bool) {
@@ -283,11 +182,6 @@ class WebViewController: UIViewController {
             themeColor: ThemeColor?,
             isTransparentBackground: Bool = false
     ) {
-        // Mask background
-        if maskBackgroud == nil {
-            maskBackgroud = addMaskBackground()
-        }
-        
         if isTransparentBackground {
             view.setGradient(
                 colors: [UIColor.clear, UIColor.clear],
@@ -317,179 +211,6 @@ class WebViewController: UIViewController {
             endPoint: CGPoint(x: 1, y: 0.5)
         )
     }
-    
-    private func addMaskBackground() -> UIView {
-        maskBackgroud = UIView(
-            frame: CGRect(
-                x: 0,
-                y: 0,
-                width: view.frame.width,
-                height: 100
-            )
-        )
-        view.addSubview(maskBackgroud)
-        
-        // Position the mask background
-        // Leading and Trailing
-        NSLayoutConstraint.activate([
-            maskBackgroud.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            maskBackgroud.trailingAnchor.constraint(equalTo: view.trailingAnchor)
-        ])
-        
-        // Top and Bottom
-        if #available(iOS 11, *) {
-            let guide = view.safeAreaLayoutGuide
-            NSLayoutConstraint.activate([
-                maskBackgroud.topAnchor.constraint(equalToSystemSpacingBelow: guide.topAnchor, multiplier: 0.0),
-                guide.bottomAnchor.constraint(equalToSystemSpacingBelow: maskBackgroud.bottomAnchor, multiplier: 0.0)
-            ])
-        } else {
-            NSLayoutConstraint.activate([
-                maskBackgroud.topAnchor.constraint(equalTo: topLayoutGuide.bottomAnchor, constant: 0),
-                bottomLayoutGuide.topAnchor.constraint(equalTo: maskBackgroud.bottomAnchor, constant: 0)
-            ])
-        }
-        
-        return maskBackgroud
-    }
-    
-    private func customizeNavBar(themeColor: ThemeColor?) {
-        guard let navBar = navigationController?.navigationBar else {
-            return
-        }
-        
-        var startColor = themeColor?.primaryBrandyStart ?? ThemeColor.default.primaryBrandyStart
-        var endColor = themeColor?.primaryBrandyEnd ?? ThemeColor.default.primaryBrandyEnd
-        if presenter.shouldUseCredifyTheme() {
-            startColor = ThemeColor.default.primaryBrandyStart
-            endColor = ThemeColor.default.primaryBrandyEnd
-        }
-        
-        navBar.setGradientBackground(
-            colors: [
-                UIColor.fromHex(startColor),
-                UIColor.fromHex(endColor)
-            ],
-            startPoint: .centerLeft,
-            endPoint: .centerRight
-        )
-        
-        // TODO I will update it later
-        let titleFont: UIFont? = nil //AppState.shared.config?.theme.font.primaryPageTitle
-        if titleFont != nil {
-            navBar.titleTextAttributes = [
-                .foregroundColor: UIColor.white,
-                .font: titleFont!
-            ]
-        } else {
-            navBar.titleTextAttributes = [
-                .foregroundColor: UIColor.white,
-            ]
-        }
-        
-        navBar.tintColor = UIColor.fromHex(themeColor?.primaryIconColor ?? "#FFFFFF")
-        if #available(iOS 13.0, *) {
-            navigationItem.leftBarButtonItem = UIBarButtonItem(
-                image: UIImage(named: "ic_back", in: Bundle.serviceX, with: nil),
-                style: .plain,
-                target: self,
-                action: #selector(goBack)
-            )
-        } else {
-            navigationItem.leftBarButtonItem = UIBarButtonItem(
-                image: UIImage(named: "ic_back", in: Bundle.serviceX, compatibleWith: nil),
-                style: .plain,
-                target: self,
-                action: #selector(goBack)
-            )
-        }
-        if #available(iOS 13.0, *) {
-            navigationItem.rightBarButtonItem = UIBarButtonItem(
-                image: UIImage(named: "ic_close", in: Bundle.serviceX, with: nil),
-                style: .plain,
-                target: self,
-                action: #selector(close)
-            )
-        } else {
-            // Fallback on earlier versions
-            navigationItem.rightBarButtonItem = UIBarButtonItem(
-                image: UIImage(named: "ic_close", in: Bundle.serviceX, compatibleWith: nil),
-                style: .plain,
-                target: self,
-                action: #selector(close)
-            )
-        }
-        
-        setBackButtonVisibility(isVisible: false)
-        navBar.isHidden = true
-    }
-    
-    @objc private func goBack() {
-        presenter.goToPreviousPageOrClose(webView: webView)
-    }
-    
-    @objc private func close() {
-        presenter.isLoading(webView: webView) { isLoading in
-            if !isLoading && !LoadingView.isShowing {
-                self.dismiss(animated: true) {
-                    self.presenter.hanldeCompletionHandler()
-                }
-            }
-        }
-    }
-
-    private func setBackButtonVisibility(isVisible: Bool) {
-        if isVisible {
-            let themeColor = AppState.shared.config?.theme.color
-            navigationItem.leftBarButtonItem?.isEnabled = true
-            navigationItem.leftBarButtonItem?.tintColor = UIColor.fromHex(themeColor?.primaryIconColor ?? "#FFFFFF")
-            return
-        }
-        
-        navigationItem.leftBarButtonItem?.isEnabled = false
-        navigationItem.leftBarButtonItem?.tintColor = .clear
-    }
-    
-    private func setCloseButtonVisibility(isVisible: Bool) {
-        if isVisible {
-            let themeColor = AppState.shared.config?.theme.color
-            navigationItem.rightBarButtonItem?.isEnabled = true
-            navigationItem.rightBarButtonItem?.tintColor = UIColor.fromHex(themeColor?.primaryIconColor ?? "#FFFFFF")
-            return
-        }
-        
-        navigationItem.rightBarButtonItem?.isEnabled = false
-        navigationItem.rightBarButtonItem?.tintColor = .clear
-    }
-}
-
-extension WebViewController: WKUIDelegate {
-    func webView(_ webView: WKWebView, runJavaScriptAlertPanelWithMessage message:
-                 String, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping () ->
-                 Void) {
-        let alertController = UIAlertController(title: message, message: nil, preferredStyle:
-                                                        .alert)
-        
-        alertController.addAction(UIAlertAction(title: "OK", style: .cancel) {_ in
-            completionHandler()})
-        
-        present(alertController, animated: true)
-    }
-    
-    func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
-        guard let url = navigationAction.request.url else {
-            return nil
-        }
-        guard let targetFrame = navigationAction.targetFrame, targetFrame.isMainFrame else {
-            let vc = SFSafariViewController(url: url)
-            let nvc = UINavigationController(rootViewController: vc)
-            nvc.modalPresentationStyle = .overFullScreen
-            present(nvc, animated: true)
-            
-            return nil
-        }
-        return nil
-    }
 }
 
 extension WebViewController: WKScriptMessageHandler{
@@ -513,12 +234,6 @@ extension WebViewController: WKScriptMessageHandler{
         }
         
         presenter.handleMessage(webView, name: message.name, body: body)
-    }
-}
-
-extension WebViewController: WKNavigationDelegate {
-    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        LoadingView.stop()
     }
 }
 


### PR DESCRIPTION
## Description
- Open a new page for opening redirect url after did redeem offer -> only apply for normal offer
- Fixed bug that HDI landing page cannot scroll

## Motivation & Context
Ticket: https://app.shortcut.com/credify/story/27632/ios-update-ios-sdk-to-help-user-can-close-the-landing-page

## How has this been tested?
Test normal offer flow. The user can redeem offer and can scroll on the extra step page(on mobile side)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.