### PR TITLE
Need to call get BNPL availability when starting BNPL [28707]

### DIFF
--- a/Credify/Credify/Objects/Entities.swift
+++ b/Credify/Credify/Objects/Entities.swift
@@ -237,7 +237,15 @@ public struct AvailableTermsDuration : Codable {
 }
 
 public struct AvailableTermsFee : Codable {
-    public let type: Int
+    public let type: String
+    public let rate: Float?
+    public let fixedValue: FiatCurrency?
+    
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case rate
+        case fixedValue = "fixed_value"
+    }
 }
 
 public struct InsurancePackageModel: Codable {


### PR DESCRIPTION
## Description
When calling method to start BNPL we need to call `getBNPLAvailability` method first.

## Motivation & Context
Ticket: ## Description
<!--- Describe your changes in detail -->

## Motivation & Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Clubhouse ticket link here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)