### PR TITLE
Using ProductType enum array [29104]

### DIFF
--- a/Credify/Credify/serviceX.swift
+++ b/Credify/Credify/serviceX.swift
@@ -93,8 +93,19 @@ public struct serviceX {
         ///   - user: User object
         ///   - productTypes: Products list
         ///   - completion: Completion handler. You can access to offers list in this handler.
-        public func getOffers(user: CredifyUserModel? = nil, productTypes: [String] = [], completion: @escaping ((Result<OfferListInfo, CredifyError>) -> Void)) {
-            return useCase.getOffers(phoneNumber: user?.phoneNumber, countryCode: user?.countryCode, internalId: user?.id ?? "", credifyId: user?.credifyId, productTypes: productTypes, completion: completion)
+        public func getOffers(
+            user: CredifyUserModel? = nil,
+            productTypes: [ProductType] = [],
+            completion: @escaping ((Result<OfferListInfo, CredifyError>) -> Void)
+        ) {
+            return useCase.getOffers(
+                phoneNumber: user?.phoneNumber,
+                countryCode: user?.countryCode,
+                internalId: user?.id ?? "",
+                credifyId: user?.credifyId,
+                productTypes: productTypes.map({ type in type.rawValue }),
+                completion: completion
+            )
         }
         
         

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ class SampleViewController: UIViewController {
     }
 
     /// This loads offers list. Please call this whenever you want.
+    /// - user: your user information. This is CredifyUserModel object.
+    /// - productTypes: The list of ProductType enum list that will be used to filter out offers.
     func loadOffers() {
         offer.getOffers(user: user, productTypes: []) { [weak self] result in
             switch result {
@@ -126,6 +128,8 @@ class SampleViewController: UIViewController {
     }
 
     /// This loads offers list. Please call this whenever you want.
+    /// - user: your user information. This is CredifyUserModel object.
+    /// - productTypes: The list of ProductType enum list that will be used to filter out offers.
     func loadOffers() {
         offer.getOffers(user: user, productTypes: []) { [weak self] result in
             switch result {


### PR DESCRIPTION
## Description
Used `ProductType` enum array instead of string array.

## Motivation & Context
Ticket: https://app.shortcut.com/credify/story/29104/mobile-sdk-using-producttype-enum-array

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.