### PR TITLE
Support to show normal offer by offer codes [29656]

### DIFF
--- a/Credify/Credify/Objects/PostMessageModel.swift
+++ b/Credify/Credify/Objects/PostMessageModel.swift
@@ -60,16 +60,16 @@ internal class StartBnplMessage: Codable {
 }
 
 internal class ShowPromotionOfferMessage: Codable {
-    let offers: [OfferData]
+    let offerCodes: [String]
     let profile: CredifyUserModel
     let theme: serviceXTheme?
     
     init(
-        offers: [OfferData],
+        offerCodes: [String],
         profile: CredifyUserModel,
         theme: serviceXTheme?
     ) {
-        self.offers = offers
+        self.offerCodes = offerCodes
         self.profile = profile
         self.theme = theme
     }

--- a/Credify/Credify/serviceX.swift
+++ b/Credify/Credify/serviceX.swift
@@ -93,6 +93,7 @@ public struct serviceX {
         ///   - user: User object
         ///   - productTypes: Products list
         ///   - completion: Completion handler. You can access to offers list in this handler.
+        @available(*, deprecated, message: "It'll be removed in the future.")
         public func getOffers(
             user: CredifyUserModel? = nil,
             productTypes: [ProductType] = [],
@@ -116,11 +117,35 @@ public struct serviceX {
         ///   - userProfile: User object
         ///   - pushClaimTokensTask: A task that calls your push claim token API. This SDK needs to receive success status of this task.
         ///   - completionHandler: Completion handler. You can get notified about the result of the offer redemption flow.
+        @available(*, deprecated, message: "Using presentByOfferCodeModally method instead")
         public func presentModally(from: UIViewController,
                                    offer: OfferData,
                                    userProfile: CredifyUserModel,
                                    pushClaimTokensTask: @escaping ((String, ((Bool) -> Void)?) -> Void),
                                    completionHandler: @escaping (RedemptionResult) -> Void) {
+            presentOfferByCodeModally(
+                from: from,
+                offerCode: offer.code,
+                userProfile: userProfile,
+                pushClaimTokensTask: pushClaimTokensTask,
+                completionHandler: completionHandler
+            )
+        }
+        
+        /// This kicks off offer redemption flow.
+        /// - Parameters:
+        ///   - from: ViewController that renders a new view from
+        ///   - offerCode: This is the offer code
+        ///   - userProfile: User object
+        ///   - pushClaimTokensTask: A task that calls your push claim token API. This SDK needs to receive success status of this task.
+        ///   - completionHandler: Completion handler. You can get notified about the result of the offer redemption flow.
+        public func presentOfferByCodeModally(
+            from: UIViewController,
+            offerCode: String,
+            userProfile: CredifyUserModel,
+            pushClaimTokensTask: @escaping ((String, ((Bool) -> Void)?) -> Void),
+            completionHandler: @escaping (RedemptionResult) -> Void
+        ) {
             if !ValidationUtils.showErrorIfOfferCannotStart(from: from, user: userProfile) {
                 return
             }
@@ -128,15 +153,39 @@ public struct serviceX {
             AppState.shared.pushClaimTokensTask = pushClaimTokensTask
             AppState.shared.redemptionResult = completionHandler
             
-            let context = PassportContext.offer(offer: offer, user: userProfile)
+            let context = PassportContext.offer(offerCode: offerCode, user: userProfile)
             let vc = WebViewController.instantiate(context: context)
             let navigationController = UIUtils.createUINavigationController(vc: vc)
             from.present(navigationController, animated: true)
         }
         
+        @available(*, deprecated, message: "Using presentPromotionOffersByCodesModally method instead")
         public func presentPromotionOffersModally(
             from: UIViewController,
             offers: [OfferData],
+            userProfile: CredifyUserModel,
+            pushClaimTokensTask: @escaping ((String, ((Bool) -> Void)?) -> Void),
+            completionHandler: @escaping (RedemptionResult) -> Void
+        ) {
+            presentPromotionOffersByCodesModally(
+                from: from,
+                offerCodes: offers.map({ item in item.code }),
+                userProfile: userProfile,
+                pushClaimTokensTask: pushClaimTokensTask,
+                completionHandler: completionHandler
+            )
+        }
+        
+        /// This will show offer list.
+        /// - Parameters:
+        ///   - from: ViewController that renders a new view from
+        ///   - offerCodes: This is  offer code list
+        ///   - userProfile: User object
+        ///   - pushClaimTokensTask: A task that calls your push claim token API. This SDK needs to receive success status of this task.
+        ///   - completionHandler: Completion handler. You can get notified about the result of the offer redemption flow.
+        public func presentPromotionOffersByCodesModally(
+            from: UIViewController,
+            offerCodes: [String],
             userProfile: CredifyUserModel,
             pushClaimTokensTask: @escaping ((String, ((Bool) -> Void)?) -> Void),
             completionHandler: @escaping (RedemptionResult) -> Void
@@ -146,7 +195,7 @@ public struct serviceX {
             }
             
             // If there is no offer then we just return, don't need to show an error to the user
-            if offers.isEmpty {
+            if offerCodes.isEmpty {
                 print("'offers' is empty")
                 return
             }
@@ -154,7 +203,7 @@ public struct serviceX {
             let vc = ModalViewController.instantiate() {
                 self.presentOffers(
                     from: from,
-                    offers: offers,
+                    offerCodes: offerCodes,
                     userProfile: userProfile,
                     pushClaimTokensTask: pushClaimTokensTask,
                     completionHandler: completionHandler
@@ -166,7 +215,7 @@ public struct serviceX {
         
         private func presentOffers(
             from: UIViewController,
-            offers: [OfferData],
+            offerCodes: [String],
             userProfile: CredifyUserModel,
             pushClaimTokensTask: @escaping ((String, ((Bool) -> Void)?) -> Void),
             completionHandler: @escaping (RedemptionResult) -> Void
@@ -174,7 +223,7 @@ public struct serviceX {
             AppState.shared.pushClaimTokensTask = pushClaimTokensTask
             AppState.shared.redemptionResult = completionHandler
             
-            let context = PassportContext.promotionOffers(offers: offers, user: userProfile)
+            let context = PassportContext.promotionOffers(offerCodes: offerCodes, user: userProfile)
             let vc = WebViewController.instantiate(context: context)
             let navigationController = UIUtils.createUINavigationController(vc: vc)
             from.present(navigationController, animated: true)

--- a/Credify/Credify/serviceX.swift
+++ b/Credify/Credify/serviceX.swift
@@ -117,13 +117,13 @@ public struct serviceX {
         ///   - userProfile: User object
         ///   - pushClaimTokensTask: A task that calls your push claim token API. This SDK needs to receive success status of this task.
         ///   - completionHandler: Completion handler. You can get notified about the result of the offer redemption flow.
-        @available(*, deprecated, message: "Using presentByOfferCodeModally method instead")
+        @available(*, deprecated, message: "Using presentOfferModallyByCode method instead")
         public func presentModally(from: UIViewController,
                                    offer: OfferData,
                                    userProfile: CredifyUserModel,
                                    pushClaimTokensTask: @escaping ((String, ((Bool) -> Void)?) -> Void),
                                    completionHandler: @escaping (RedemptionResult) -> Void) {
-            presentOfferByCodeModally(
+            presentOfferModallyByCode(
                 from: from,
                 offerCode: offer.code,
                 userProfile: userProfile,
@@ -139,7 +139,7 @@ public struct serviceX {
         ///   - userProfile: User object
         ///   - pushClaimTokensTask: A task that calls your push claim token API. This SDK needs to receive success status of this task.
         ///   - completionHandler: Completion handler. You can get notified about the result of the offer redemption flow.
-        public func presentOfferByCodeModally(
+        public func presentOfferModallyByCode(
             from: UIViewController,
             offerCode: String,
             userProfile: CredifyUserModel,


### PR DESCRIPTION
## Description
- Added methods(`presentOfferByCodeModally`, `presentPromotionOffersByCodesModally`) to show offer by codes
- Mark as deprecated methods(`getOfferList `, `presentModally `, `presentPromotionOffersModally`)
- I will update the Readme file after finished for both BNPL and normal flow

## Motivation & Context
Ticket: https://app.shortcut.com/credify/story/29656/mobile-support-to-show-normal-offer-by-offer-codes

## How has this been tested?
Test normal offer flow. The user can see offer detail and redeem that offer.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.